### PR TITLE
FCE-378 Remove exact websocket address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-.yarn/*
+.yarn
 !.yarn/cache
 !.yarn/patches
 !.yarn/plugins

--- a/examples/room-manager/src/rooms.ts
+++ b/examples/room-manager/src/rooms.ts
@@ -4,16 +4,23 @@ import { ServerMessage } from '@fishjam-cloud/js-server-sdk/proto';
 import { parseError } from './utils';
 import { peerEndpointSchema, QueryParams, startRecordingSchema } from './schema';
 
+const removeTrailingSlash = (href: string) => href.endsWith("/") ? href.slice(0, -1) : href
+
 const httpToWebsocket = (httpUrl: string) => {
   const url = new URL(httpUrl);
 
   // note that this will handle http as well as https
   url.protocol = url.protocol.replace('http', 'ws');
+
   return url.href;
 };
 
 export async function roomsEndpoints(fastify: FastifyInstance) {
-  const websocketUrl = `${httpToWebsocket(fastify.config.FISHJAM_URL)}/socket/peer/websocket`;
+  const url = httpToWebsocket(fastify.config.FISHJAM_URL);
+
+  // When creating a URL object from a URL without a path (e.g., `http://localhost:5002`),
+  // the `href` field may contain an additional '/' at the end (`http://localhost:5002/`).
+  const websocketUrl = removeTrailingSlash(url);
   const roomService = new RoomService(fastify.config.FISHJAM_URL, fastify.config.FISHJAM_SERVER_TOKEN);
 
   fastify.get<{ Params: QueryParams }>(


### PR DESCRIPTION
## Description

`url` field in `/:roomName/users/:username` endpoint does not contain `/socket/peer/websocket` any more

## Motivation and Context

Currently, the room-manager adds `/socket/peer/websocket` to the `FISHJAM_URL` variable because the client SDKs are not aware of this information. This knowledge should be moved from the room-manager to the client SDKs.

## Types of changes

Breaking change (fix or feature that would cause existing functionality to not work as expected)
