### PR TITLE
Fix room manager CI docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .yarn
+!.yarn/releases
 .prettierrc
 .prettierignore
 .github

--- a/examples/room-manager/Dockerfile
+++ b/examples/room-manager/Dockerfile
@@ -14,7 +14,7 @@ COPY . .
 RUN yarn --immutable
 
 # Step 2: Build the SDK
-RUN yarn workspace @fishjam-cloud/js-server-sdk build
+RUN yarn build
 
 # Step 3: Run the example
 WORKDIR /app/examples/room-manager


### PR DESCRIPTION
## Description
`.dockerignore`
Because `yarn` is embedded in this repository in `.yarn/releases`, this release is used in the Docker container as well.

`examples/room-manager/Dockerfile`
Build all packages because `room-manager` requires `@fishjam-cloud/js-server-sdk`, which in turn requires `@fishjam-cloud/fishjam-openapi` and `@fishjam-cloud/fishjam-proto`.

## Motivation and Context
To fix the broken `room-manager` build.

## Types of changes

Bug fix (non-breaking change which fixes an issue)
