### PR TITLE
Do not minify server-side code

### DIFF
--- a/packages/fishjam-openapi/package.json
+++ b/packages/fishjam-openapi/package.json
@@ -30,7 +30,7 @@
       "src/index.ts"
     ],
     "dts": true,
-    "minify": true,
+    "minify": false,
     "format": [
       "cjs",
       "esm"

--- a/packages/fishjam-proto/package.json
+++ b/packages/fishjam-proto/package.json
@@ -30,7 +30,7 @@
       "src/index.ts"
     ],
     "dts": true,
-    "minify": true,
+    "minify": false,
     "format": [
       "cjs",
       "esm"

--- a/packages/js-server-sdk/package.json
+++ b/packages/js-server-sdk/package.json
@@ -39,7 +39,7 @@
       "src/proto.ts"
     ],
     "dts": true,
-    "minify": true,
+    "minify": false,
     "format": [
       "cjs",
       "esm"


### PR DESCRIPTION
## Description

This turns off minification for all SDK packages.

## Motivation and Context

Debugging minified code is painful, and source maps wouldn't solve the issue of logging error types correctly. Minification has a negligible performance impact for server-side code, and turning it off improves developer experience.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
