### PR TITLE
[FCE-1127] Update API docs

### DIFF
--- a/packages/js-server-sdk/package.json
+++ b/packages/js-server-sdk/package.json
@@ -28,7 +28,7 @@
     "./proto": "./dist/proto.js"
   },
   "scripts": {
-    "build": "tsup --dts-resolve",
+    "build": "tsup --dts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit",

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -3,6 +3,11 @@ import { RoomApi, RoomConfig, PeerOptions, Peer } from '@fishjam-cloud/fishjam-o
 import { FishjamConfig, Room } from './types';
 import { raiseExceptions } from './exceptions/mapper';
 
+/**
+ * Client class that allows to manage Rooms and Peers for Fishjam App.
+ * It requires Fishjam URL and management token that can be retrieved from Fishjam Dashboard.
+ * @category Client
+ */
 export class FishjamClient {
   private readonly roomApi: RoomApi;
 
@@ -16,6 +21,45 @@ export class FishjamClient {
     this.roomApi = new RoomApi(undefined, config.fishjamUrl, client);
   }
 
+  /**
+   * Create new room. All peers connected to same room will be able to send/receive streams to each other
+   */
+  async createRoom(config: RoomConfig = {}): Promise<Room> {
+    const response = await this.roomApi.createRoom(config).catch(raiseExceptions);
+
+    const {
+      data: {
+        data: {
+          room: { components: _, ...room },
+        },
+      },
+    } = response;
+
+    return room;
+  }
+
+  /**
+   * Delete existing room. All peers connected to this room will be disconnected and removed.
+   * @param roomId
+   */
+  async deleteRoom(roomId: string): Promise<void> {
+    await this.roomApi.deleteRoom(roomId).catch((error) => raiseExceptions(error, 'room'));
+  }
+
+  /**
+   * Get list of all existing rooms.
+   */
+  async getAllRooms(): Promise<Room[]> {
+    const getAllRoomsRepsonse = await this.roomApi.getAllRooms().catch(raiseExceptions);
+    return getAllRoomsRepsonse.data.data.map(({ components: _, ...room }) => room) ?? [];
+  }
+
+  /**
+   * Create new peer assigned to room
+   * @param roomId
+   * @param options
+   * @returns
+   */
   async createPeer(roomId: string, options: PeerOptions = {}): Promise<{ peer: Peer; peerToken: string }> {
     const response = await this.roomApi
       .addPeer(roomId, {
@@ -31,39 +75,33 @@ export class FishjamClient {
     return { peer: data.peer, peerToken: data.token };
   }
 
-  async createRoom(config: RoomConfig = {}): Promise<Room> {
-    const response = await this.roomApi.createRoom(config).catch(raiseExceptions);
-
-    const {
-      data: {
-        data: {
-          room: { components: _, ...room },
-        },
-      },
-    } = response;
-
-    return room;
-  }
-
-  async getAllRooms(): Promise<Room[]> {
-    const getAllRoomsRepsonse = await this.roomApi.getAllRooms().catch(raiseExceptions);
-    return getAllRoomsRepsonse.data.data.map(({ components: _, ...room }) => room) ?? [];
-  }
-
+  /**
+   * Get details about given room
+   * @param roomId
+   * @returns
+   */
   async getRoom(roomId: string): Promise<Room> {
     const getRoomResponse = await this.roomApi.getRoom(roomId).catch((error) => raiseExceptions(error, 'room'));
     const { components: _, ...room } = getRoomResponse.data.data;
     return room;
   }
 
+  /**
+   * Delete peer - this will also disconnect peer from room
+   * @param roomId
+   * @param peerId
+   */
   async deletePeer(roomId: string, peerId: string): Promise<void> {
     await this.roomApi.deletePeer(roomId, peerId).catch((error) => raiseExceptions(error, 'peer'));
   }
 
-  async deleteRoom(roomId: string): Promise<void> {
-    await this.roomApi.deleteRoom(roomId).catch((error) => raiseExceptions(error, 'room'));
-  }
-
+  /**
+   * Refresh peer token for already existing peer.
+   * If  already created peer was not connected to room for more than 24 hours, token will became invalid. This method can be used to generate new peer_token for existing peer.
+   * @param roomId
+   * @param peerId
+   * @returns
+   */
   async refreshPeerToken(roomId: string, peerId: string): Promise<string> {
     const refreshTokenResponse = await this.roomApi
       .refreshToken(roomId, peerId)

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -22,7 +22,7 @@ export class FishjamClient {
   }
 
   /**
-   * Create new room. All peers connected to same room will be able to send/receive streams to each other
+   * Create a new room. All peers connected to the same room will be able to send/receive streams to each other.
    */
   async createRoom(config: RoomConfig = {}): Promise<Room> {
     const response = await this.roomApi.createRoom(config).catch(raiseExceptions);
@@ -39,7 +39,7 @@ export class FishjamClient {
   }
 
   /**
-   * Delete existing room. All peers connected to this room will be disconnected and removed.
+   * Delete an existing room. All peers connected to this room will be disconnected and removed.
    * @param roomId
    */
   async deleteRoom(roomId: string): Promise<void> {
@@ -47,7 +47,7 @@ export class FishjamClient {
   }
 
   /**
-   * Get list of all existing rooms.
+   * Get a list of all existing rooms.
    */
   async getAllRooms(): Promise<Room[]> {
     const getAllRoomsRepsonse = await this.roomApi.getAllRooms().catch(raiseExceptions);
@@ -55,7 +55,7 @@ export class FishjamClient {
   }
 
   /**
-   * Create new peer assigned to room
+   * Create a new peer assigned to a room.
    * @param roomId
    * @param options
    * @returns
@@ -76,7 +76,7 @@ export class FishjamClient {
   }
 
   /**
-   * Get details about given room
+   * Get details about a given room.
    * @param roomId
    * @returns
    */
@@ -87,7 +87,7 @@ export class FishjamClient {
   }
 
   /**
-   * Delete peer - this will also disconnect peer from room
+   * Delete a peer - this will also disconnect the peer from the room.
    * @param roomId
    * @param peerId
    */
@@ -96,8 +96,8 @@ export class FishjamClient {
   }
 
   /**
-   * Refresh peer token for already existing peer.
-   * If  already created peer was not connected to room for more than 24 hours, token will became invalid. This method can be used to generate new peer_token for existing peer.
+   * Refresh the peer token for an already existing peer.
+   * If an already created peer has not been connected to the room for more than 24 hours, the token will become invalid. This method can be used to generate a new peer token for the existing peer.
    * @param roomId
    * @param peerId
    * @returns refreshed peer token

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -100,7 +100,7 @@ export class FishjamClient {
    * If  already created peer was not connected to room for more than 24 hours, token will became invalid. This method can be used to generate new peer_token for existing peer.
    * @param roomId
    * @param peerId
-   * @returns
+   * @returns refreshed peer token
    */
   async refreshPeerToken(roomId: string, peerId: string): Promise<string> {
     const refreshTokenResponse = await this.roomApi

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -4,8 +4,8 @@ import { FishjamConfig, Room } from './types';
 import { raiseExceptions } from './exceptions/mapper';
 
 /**
- * Client class that allows to manage Rooms and Peers for Fishjam App.
- * It requires Fishjam URL and management token that can be retrieved from Fishjam Dashboard.
+ * Client class that allows to manage Rooms and Peers for a Fishjam App.
+ * It requires the Fishjam URL and management token that can be retrieved from the Fishjam Dashboard.
  * @category Client
  */
 export class FishjamClient {

--- a/packages/js-server-sdk/src/index.ts
+++ b/packages/js-server-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export { Peer, PeerStatus, RoomConfig, PeerOptions } from '@fishjam-cloud/fishjam-openapi';
 export { FishjamWSNotifier } from './ws_notifier';
+export type { CloseEventHandler, ErrorEventHandler, NotificationEvents, AllowedNotifications } from './ws_notifier';
 export { FishjamClient } from './client';
 export * from './exceptions';
 export type * from './types';

--- a/packages/js-server-sdk/src/index.ts
+++ b/packages/js-server-sdk/src/index.ts
@@ -1,6 +1,6 @@
 export { Peer, PeerStatus, RoomConfig, PeerOptions } from '@fishjam-cloud/fishjam-openapi';
 export { FishjamWSNotifier } from './ws_notifier';
-export type { CloseEventHandler, ErrorEventHandler, NotificationEvents, AllowedNotifications } from './ws_notifier';
+export type { CloseEventHandler, ErrorEventHandler, NotificationEvents, ExpectedEvents } from './ws_notifier';
 export { FishjamClient } from './client';
 export * from './exceptions';
 export type * from './types';

--- a/packages/js-server-sdk/src/ws_notifier.ts
+++ b/packages/js-server-sdk/src/ws_notifier.ts
@@ -5,7 +5,21 @@ import { ServerMessage, ServerMessage_EventType } from './proto';
 import { FishjamConfig } from './types';
 import { httpToWebsocket } from './utlis';
 
-const allowedNotifications = [
+export type AllowedNotifications =
+  | 'roomCreated'
+  | 'roomDeleted'
+  | 'roomCrashed'
+  | 'peerAdded'
+  | 'peerDeleted'
+  | 'peerConnected'
+  | 'peerDisconnected'
+  | 'peerMetadataUpdated'
+  | 'peerCrashed'
+  | 'trackAdded'
+  | 'trackRemoved'
+  | 'trackMetadataUpdated';
+
+const allowedNotificationsList: ReadonlyArray<AllowedNotifications> = [
   'roomCreated',
   'roomDeleted',
   'roomCrashed',
@@ -20,10 +34,14 @@ const allowedNotifications = [
   'trackMetadataUpdated',
 ] as const;
 
-type ErrorEventHandler = (msg: Error) => void;
-type CloseEventHandler = (code: number, reason: string) => void;
-type NotificationEvents = Record<(typeof allowedNotifications)[number], (message: ServerMessage) => void>;
+export type ErrorEventHandler = (msg: Error) => void;
+export type CloseEventHandler = (code: number, reason: string) => void;
+export type NotificationEvents = Record<AllowedNotifications, (message: ServerMessage) => void>;
 
+/**
+ * Notifier object that can be used to notify about various events related to Fishjam App
+ * @category Client
+ */
 export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<NotificationEvents>) {
   private readonly client: WebSocket.client;
 
@@ -86,7 +104,7 @@ export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<N
     connection.on('close', (code, reason) => onClose(code, reason));
   }
 
-  private isAllowedNotification(notification: string): notification is (typeof allowedNotifications)[number] {
-    return allowedNotifications.includes(notification as (typeof allowedNotifications)[number]);
+  private isAllowedNotification(notification: string): notification is AllowedNotifications {
+    return allowedNotificationsList.includes(notification as AllowedNotifications);
   }
 }

--- a/packages/js-server-sdk/src/ws_notifier.ts
+++ b/packages/js-server-sdk/src/ws_notifier.ts
@@ -5,7 +5,7 @@ import { ServerMessage, ServerMessage_EventType } from './proto';
 import { FishjamConfig } from './types';
 import { httpToWebsocket } from './utlis';
 
-export type AllowedNotifications =
+export type ExpectedEvents =
   | 'roomCreated'
   | 'roomDeleted'
   | 'roomCrashed'
@@ -19,7 +19,7 @@ export type AllowedNotifications =
   | 'trackRemoved'
   | 'trackMetadataUpdated';
 
-const allowedNotificationsList: ReadonlyArray<AllowedNotifications> = [
+const expectedEventsList: ReadonlyArray<ExpectedEvents> = [
   'roomCreated',
   'roomDeleted',
   'roomCrashed',
@@ -36,7 +36,7 @@ const allowedNotificationsList: ReadonlyArray<AllowedNotifications> = [
 
 export type ErrorEventHandler = (msg: Error) => void;
 export type CloseEventHandler = (code: number, reason: string) => void;
-export type NotificationEvents = Record<AllowedNotifications, (message: ServerMessage) => void>;
+export type NotificationEvents = Record<ExpectedEvents, (message: ServerMessage) => void>;
 
 /**
  * Notifier object that can be used to get notified about various events related to the Fishjam App.
@@ -75,7 +75,7 @@ export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<N
       const decodedMessage = ServerMessage.toJSON(ServerMessage.decode(message.binaryData)) as Record<string, string>;
       const [notification] = Object.keys(decodedMessage);
 
-      if (!this.isAllowedNotification(notification)) return;
+      if (!this.isExpectedEvent(notification)) return;
 
       this.emit(notification, decodedMessage);
     } catch (e) {
@@ -104,7 +104,7 @@ export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<N
     connection.on('close', (code, reason) => onClose(code, reason));
   }
 
-  private isAllowedNotification(notification: string): notification is AllowedNotifications {
-    return allowedNotificationsList.includes(notification as AllowedNotifications);
+  private isExpectedEvent(notification: string): notification is ExpectedEvents {
+    return expectedEventsList.includes(notification as ExpectedEvents);
   }
 }

--- a/packages/js-server-sdk/src/ws_notifier.ts
+++ b/packages/js-server-sdk/src/ws_notifier.ts
@@ -39,7 +39,7 @@ export type CloseEventHandler = (code: number, reason: string) => void;
 export type NotificationEvents = Record<AllowedNotifications, (message: ServerMessage) => void>;
 
 /**
- * Notifier object that can be used to notify about various events related to Fishjam App
+ * Notifier object that can be used to get notified about various events related to the Fishjam App.
  * @category Client
  */
 export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<NotificationEvents>) {

--- a/packages/js-server-sdk/typedoc.json
+++ b/packages/js-server-sdk/typedoc.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "includeVersion": true,
-  "entryPoints": ["src/index.ts", "src/proto.ts"]
+  "entryPoints": ["src/index.ts", "src/proto.ts"],
+  "categoryOrder": ["Connection", "Devices", "Screenshare", "Components", "*", "Debugging"],
+  "sort": ["kind", "alphabetical"],
+  "kindSortOrder": ["Method", "Function"],
+  "readme": "none"
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,9 +1,11 @@
 {
-  "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["packages/*"],
-  "name": "Fishjam SDK",
+  "entryPoints": ["packages/js-server-sdk*"],
+  "name": "Fishjam Server SDK",
   "entryPointStrategy": "packages",
   "includeVersion": true,
   "plugin": ["typedoc-material-theme"],
-  "themeColor": "#FCF6E7"
+  "themeColor": "#FCF6E7",
+  "readme": "none",
+  "treatValidationWarningsAsErrors": true,
+  "treatWarningsAsErrors": true
 }


### PR DESCRIPTION
## Description

It would be nice ot have some TypeDoc comments added to project. This way we can add js-server-doc API into our official documentation

## Motivation and Context

Our server SDKs are not well documented, so when clients will decide to implement their backend - it won't be as easy as code for frontend

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
