### PR TITLE
FCE-1185: Change default codec for video-room to VP8

### DIFF
--- a/examples/room-manager/src/config.ts
+++ b/examples/room-manager/src/config.ts
@@ -8,6 +8,7 @@ declare module 'fastify' {
       MAX_PEERS?: number;
       FISHJAM_URL: string;
       FISHJAM_SERVER_TOKEN: string;
+      ROOM_VIDEO_CODEC: string;
     };
   }
 }
@@ -42,6 +43,10 @@ export const configSchema = {
     FISHJAM_SERVER_TOKEN: {
       type: 'string',
       default: 'development',
+    },
+    ROOM_VIDEO_CODEC: {
+      type: 'string',
+      default: 'vp8',
     },
   },
 };

--- a/examples/room-manager/src/plugins/fishjam.ts
+++ b/examples/room-manager/src/plugins/fishjam.ts
@@ -2,6 +2,7 @@ import fastifyPlugin from 'fastify-plugin';
 import { type FastifyInstance } from 'fastify';
 import { FishjamClient, Room, RoomNotFoundException } from '@fishjam-cloud/js-server-sdk';
 import { ServerMessage } from '@fishjam-cloud/js-server-sdk/proto';
+import { type RoomConfigVideoCodecEnum } from '@fishjam-cloud/fishjam-openapi';
 import { RoomManagerError } from '../errors';
 import { PeerAccessData } from '../schema';
 
@@ -146,6 +147,7 @@ export const fishjamPlugin = fastifyPlugin(async (fastify: FastifyInstance): Pro
       maxPeers: fastify.config.MAX_PEERS,
       webhookUrl: fastify.config.WEBHOOK_URL,
       peerlessPurgeTimeout: fastify.config.PEERLESS_PURGE_TIMEOUT,
+      videoCodec: fastify.config.ROOM_VIDEO_CODEC as RoomConfigVideoCodecEnum,
     });
 
     roomNameToRoomIdMap.set(roomName, newRoom.id);


### PR DESCRIPTION
## Description

- Set default codec do vp8 when creating new room with room manager

## Motivation and Context

- Android emulator doesn't support H264 by default, so this will allow for better compatibility

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
