### PR TITLE
[FCE-1243] Fix error logging

### DIFF
--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -36,66 +36,88 @@ export class FishjamClient {
    * Create a new room. All peers connected to the same room will be able to send/receive streams to each other.
    */
   async createRoom(config: RoomConfig = {}): Promise<Room> {
-    const response = await this.roomApi.createRoom(config).catch(raiseExceptions);
+    try {
+      const response = await this.roomApi.createRoom(config);
 
-    const {
-      data: {
+      const {
         data: {
-          room: { components: _, ...room },
+          data: {
+            room: { components: _, ...room },
+          },
         },
-      },
-    } = response;
+      } = response;
 
-    return room as Room;
+      return room as Room;
+    } catch (error) {
+      throw raiseExceptions(error);
+    }
   }
 
   /**
    * Delete an existing room. All peers connected to this room will be disconnected and removed.
    */
   async deleteRoom(roomId: RoomId): Promise<void> {
-    await this.roomApi.deleteRoom(roomId).catch((error) => raiseExceptions(error, 'room'));
+    try {
+      await this.roomApi.deleteRoom(roomId);
+    } catch (error) {
+      throw raiseExceptions(error, 'room');
+    }
   }
 
   /**
    * Get a list of all existing rooms.
    */
   async getAllRooms(): Promise<Room[]> {
-    const getAllRoomsResponse = await this.roomApi.getAllRooms().catch(raiseExceptions);
-    return getAllRoomsResponse.data.data.map(({ components: _, ...room }) => room as Room) ?? [];
+    try {
+      const getAllRoomsResponse = await this.roomApi.getAllRooms();
+      return getAllRoomsResponse.data.data.map(({ components: _, ...room }) => room as Room) ?? [];
+    } catch (error) {
+      throw raiseExceptions(error);
+    }
   }
 
   /**
    * Create a new peer assigned to a room.
    */
   async createPeer(roomId: RoomId, options: PeerOptions = {}): Promise<{ peer: Peer; peerToken: string }> {
-    const response = await this.roomApi
-      .addPeer(roomId, {
+    try {
+      const response = await this.roomApi.addPeer(roomId, {
         type: 'webrtc',
         options,
-      })
-      .catch(raiseExceptions);
+      });
 
-    const {
-      data: { data },
-    } = response;
+      const {
+        data: { data },
+      } = response;
 
-    return { peer: data.peer as Peer, peerToken: data.token };
+      return { peer: data.peer as Peer, peerToken: data.token };
+    } catch (error) {
+      throw raiseExceptions(error);
+    }
   }
 
   /**
    * Get details about a given room.
    */
   async getRoom(roomId: RoomId): Promise<Room> {
-    const getRoomResponse = await this.roomApi.getRoom(roomId).catch((error) => raiseExceptions(error, 'room'));
-    const { components: _, ...room } = getRoomResponse.data.data;
-    return room as Room;
+    try {
+      const getRoomResponse = await this.roomApi.getRoom(roomId);
+      const { components: _, ...room } = getRoomResponse.data.data;
+      return room as Room;
+    } catch (error) {
+      throw raiseExceptions(error, 'room');
+    }
   }
 
   /**
    * Delete a peer - this will also disconnect the peer from the room.
    */
   async deletePeer(roomId: RoomId, peerId: PeerId): Promise<void> {
-    await this.roomApi.deletePeer(roomId, peerId).catch((error) => raiseExceptions(error, 'peer'));
+    try {
+      await this.roomApi.deletePeer(roomId, peerId);
+    } catch (error) {
+      throw raiseExceptions(error, 'peer');
+    }
   }
 
   /**
@@ -104,9 +126,11 @@ export class FishjamClient {
    * @returns refreshed peer token
    */
   async refreshPeerToken(roomId: RoomId, peerId: PeerId): Promise<string> {
-    const refreshTokenResponse = await this.roomApi
-      .refreshToken(roomId, peerId)
-      .catch((error) => raiseExceptions(error, 'peer'));
-    return refreshTokenResponse.data.data.token;
+    try {
+      const refreshTokenResponse = await this.roomApi.refreshToken(roomId, peerId);
+      return refreshTokenResponse.data.data.token;
+    } catch (error) {
+      throw raiseExceptions(error, 'peer');
+    }
   }
 }

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { RoomApi, RoomConfig, PeerOptions } from '@fishjam-cloud/fishjam-openapi';
 import { FishjamConfig, PeerId, Room, RoomId, Peer } from './types';
-import { raiseExceptions } from './exceptions/mapper';
+import { mapException } from './exceptions/mapper';
 
 /**
  * Client class that allows to manage Rooms and Peers for a Fishjam App.
@@ -49,7 +49,7 @@ export class FishjamClient {
 
       return room as Room;
     } catch (error) {
-      throw raiseExceptions(error);
+      throw mapException(error);
     }
   }
 
@@ -60,7 +60,7 @@ export class FishjamClient {
     try {
       await this.roomApi.deleteRoom(roomId);
     } catch (error) {
-      throw raiseExceptions(error, 'room');
+      throw mapException(error, 'room');
     }
   }
 
@@ -72,7 +72,7 @@ export class FishjamClient {
       const getAllRoomsResponse = await this.roomApi.getAllRooms();
       return getAllRoomsResponse.data.data.map(({ components: _, ...room }) => room as Room) ?? [];
     } catch (error) {
-      throw raiseExceptions(error);
+      throw mapException(error);
     }
   }
 
@@ -92,7 +92,7 @@ export class FishjamClient {
 
       return { peer: data.peer as Peer, peerToken: data.token };
     } catch (error) {
-      throw raiseExceptions(error);
+      throw mapException(error);
     }
   }
 
@@ -105,7 +105,7 @@ export class FishjamClient {
       const { components: _, ...room } = getRoomResponse.data.data;
       return room as Room;
     } catch (error) {
-      throw raiseExceptions(error, 'room');
+      throw mapException(error, 'room');
     }
   }
 
@@ -116,7 +116,7 @@ export class FishjamClient {
     try {
       await this.roomApi.deletePeer(roomId, peerId);
     } catch (error) {
-      throw raiseExceptions(error, 'peer');
+      throw mapException(error, 'peer');
     }
   }
 
@@ -130,7 +130,7 @@ export class FishjamClient {
       const refreshTokenResponse = await this.roomApi.refreshToken(roomId, peerId);
       return refreshTokenResponse.data.data.token;
     } catch (error) {
-      throw raiseExceptions(error, 'peer');
+      throw mapException(error, 'peer');
     }
   }
 }

--- a/packages/js-server-sdk/src/exceptions/index.ts
+++ b/packages/js-server-sdk/src/exceptions/index.ts
@@ -2,9 +2,13 @@ import axios from 'axios';
 
 export class FishjamBaseException extends Error {
   statusCode: number;
+  axiosCode?: string;
+  details?: string;
   constructor(error: axios.AxiosError<Record<string, string>>) {
-    super(error.response?.data['detail'] ?? error.response?.data['errors'] ?? 'Unknown error');
+    super(error.message);
     this.statusCode = error.response?.status ?? 500;
+    this.axiosCode = error.code;
+    this.details = error.response?.data['detail'] ?? error.response?.data['errors'] ?? 'Unknown error';
   }
 }
 
@@ -21,3 +25,5 @@ export class FishjamNotFoundException extends FishjamBaseException {}
 export class PeerNotFoundException extends FishjamBaseException {}
 
 export class ServiceUnavailableException extends FishjamBaseException {}
+
+export class UnknownException extends FishjamBaseException {}

--- a/packages/js-server-sdk/src/exceptions/index.ts
+++ b/packages/js-server-sdk/src/exceptions/index.ts
@@ -21,5 +21,3 @@ export class FishjamNotFoundException extends FishjamBaseException {}
 export class PeerNotFoundException extends FishjamBaseException {}
 
 export class ServiceUnavailableException extends FishjamBaseException {}
-
-export class UnknownException extends FishjamBaseException {}

--- a/packages/js-server-sdk/src/exceptions/mapper.ts
+++ b/packages/js-server-sdk/src/exceptions/mapper.ts
@@ -35,5 +35,7 @@ export const mapException = (error: unknown, entity?: 'peer' | 'room') => {
       default:
         return new UnknownException(error);
     }
-  } else return error;
+  } else {
+    return error;
+  }
 };

--- a/packages/js-server-sdk/src/exceptions/mapper.ts
+++ b/packages/js-server-sdk/src/exceptions/mapper.ts
@@ -6,6 +6,7 @@ import {
   RoomNotFoundException,
   ServiceUnavailableException,
   UnauthorizedException,
+  UnknownException,
 } from '.';
 type AxiosError = axios.AxiosError<Record<string, string>>;
 function isAxiosException(error: unknown): error is AxiosError {
@@ -31,6 +32,8 @@ export const raiseExceptions = (error: unknown, entity?: 'peer' | 'room') => {
 
       case 503:
         return new ServiceUnavailableException(error);
+      default:
+        return new UnknownException(error);
     }
   } else return error;
 };

--- a/packages/js-server-sdk/src/exceptions/mapper.ts
+++ b/packages/js-server-sdk/src/exceptions/mapper.ts
@@ -13,7 +13,7 @@ function isAxiosException(error: unknown): error is AxiosError {
   return !!error && typeof error === 'object' && 'isAxiosError' in error && !!error.isAxiosError;
 }
 
-export const raiseExceptions = (error: unknown, entity?: 'peer' | 'room') => {
+export const mapException = (error: unknown, entity?: 'peer' | 'room') => {
   if (isAxiosException(error)) {
     switch (error.response?.status) {
       case 400:


### PR DESCRIPTION
## Description

Improve error logging in FishjamClient by passing more information about error back to user.

## Motivation and Context

Before this PR, error mapper 'eat up' part of error information, so when SDK was used with incorrect configuration, 'generic error' was thrown. Without more details about what exactly is going on. After this PR, errors should contain at least some clues on what could be wrong.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
