### PR TITLE
FCE-1256 refresh token 

### DIFF
--- a/examples/room-manager/src/plugins/fishjam.ts
+++ b/examples/room-manager/src/plugins/fishjam.ts
@@ -53,6 +53,8 @@ export const fishjamPlugin = fastifyPlugin(async (fastify: FastifyInstance): Pro
 
     if (!peerAccess?.peerToken) throw new RoomManagerError('Missing peer token in room');
 
+    peerAccess.peerToken = await fishjamClient.refreshPeerToken(room.id, peer.id);
+
     fastify.log.info({ name: 'Peer and room exist', username, roomName });
 
     return peerAccess;


### PR DESCRIPTION
## Description

Refreshes the peer token each time he asks for the access, making sure the token is always valid.

## Motivation and Context

Room manager cached stale tokens.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
