### PR TITLE
[FCE-1244] Change token name again

### DIFF
--- a/.github/workflows/build-and-test-room-manager-amd64.yaml
+++ b/.github/workflows/build-and-test-room-manager-amd64.yaml
@@ -9,49 +9,49 @@ on:
   workflow_dispatch:
 
 jobs:
-    build-and-test-amd64-image:
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - name: Checkout Repository
-              uses: actions/checkout@v4
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-            - name: Login to GitHub Container Registry
-              uses: docker/login-action@v3
-              with:
-                registry: ghcr.io
-                username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Build and push Docker image
-              uses: docker/build-push-action@v6
-              with:
-                file: examples/room-manager/Dockerfile
-                platforms: linux/amd64
-                cache-from: type=gha
-                cache-to: type=gha,mode=max
-                tags: room-manager:${{ github.event.pull_request.head.sha }}
-                load: true
-            - name: Run Room Manager
-              run: |
-                docker run -d -p 8080:8080 \
-                --name gh-runner-room-manager \
-                --restart always \
-                -e PORT=8080 \
-                -e PEERLESS_PURGE_TIMEOUT=600 \
-                -e FISHJAM_URL=${{ vars.ROOM_MANAGER_FISHJAM_URL }} \
-                -e FISHJAM_SERVER_TOKEN=${{ vars.ROOM_MANAGER_FISHJAM_SERVER_TOKEN }} \
-                room-manager:${{ github.event.pull_request.head.sha }}
-            - name: Test Room Manager Healtcheck
-              run: |
-                sleep 2
-                curl -o tmp1.json -s -vvv http://127.0.0.1:8080/health
-                jq . tmp1.json
-                [[ $(jq -r .status tmp1.json) == "ok" ]]
-            - name: Test Room Manager API
-              run: |
-                 curl -o tmp2.json -s -vvv "http://127.0.0.1:8080/api/rooms?roomName=testRoomName&peerName=testPeerName"
-                 jq '{peerToken: .peerToken, room: .room, peer: .peer}' tmp2.json
-                 [[ $(jq -r .peerToken tmp2.json) != "null" ]]
+  build-and-test-amd64-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          file: examples/room-manager/Dockerfile
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: room-manager:${{ github.event.pull_request.head.sha }}
+          load: true
+      - name: Run Room Manager
+        run: |
+          docker run -d -p 8080:8080 \
+          --name gh-runner-room-manager \
+          --restart always \
+          -e PORT=8080 \
+          -e PEERLESS_PURGE_TIMEOUT=600 \
+          -e FISHJAM_URL=${{ vars.ROOM_MANAGER_FISHJAM_URL }} \
+          -e FISHJAM_MANAGEMENT_TOKEN=${{ vars.ROOM_MANAGER_FISHJAM_SERVER_TOKEN }} \
+          room-manager:${{ github.event.pull_request.head.sha }}
+      - name: Test Room Manager Healtcheck
+        run: |
+          sleep 2
+          curl -o tmp1.json -s -vvv http://127.0.0.1:8080/health
+          jq . tmp1.json
+          [[ $(jq -r .status tmp1.json) == "ok" ]]
+      - name: Test Room Manager API
+        run: |
+          curl -o tmp2.json -s -vvv "http://127.0.0.1:8080/api/rooms?roomName=testRoomName&peerName=testPeerName"
+          jq '{peerToken: .peerToken, room: .room, peer: .peer}' tmp2.json
+          [[ $(jq -r .peerToken tmp2.json) != "null" ]]

--- a/.github/workflows/deploy-room-manager.yaml
+++ b/.github/workflows/deploy-room-manager.yaml
@@ -28,6 +28,6 @@ jobs:
           -e PORT=8080 \
           -e PEERLESS_PURGE_TIMEOUT=600 \
           -e FISHJAM_URL=${{ secrets.ROOM_MANAGER_FISHJAM_URL }} \
-          -e FISHJAM_SERVER_TOKEN=${{ secrets.ROOM_MANAGER_FISHJAM_SERVER_TOKEN }} \
+          -e FISHJAM_MANAGEMENT_TOKEN=${{ secrets.ROOM_MANAGER_FISHJAM_SERVER_TOKEN }} \
           -e WEBHOOK_URL=${{ secrets.ROOM_MANAGER_WEBHOOK_URL }} \
           gh-runner-room-manager

--- a/examples/room-manager/README.md
+++ b/examples/room-manager/README.md
@@ -28,7 +28,7 @@ docker build -t room-manager -f examples/room-manager/Dockerfile .
 2. Run the following command with `{url}` and `{token}` placeholders replaced to start the Room Manager:
 
 ```sh
-docker run -e FISHJAM_URL={url} -e FISHJAM_SERVER_TOKEN={token} -d -p 8000:8080 room-manager:latest
+docker run -e FISHJAM_URL={url} -e FISHJAM_MANAGEMENT_TOKEN={token} -d -p 8000:8080 room-manager:latest
 ```
 
 ## API

--- a/examples/room-manager/src/config.ts
+++ b/examples/room-manager/src/config.ts
@@ -7,7 +7,9 @@ declare module 'fastify' {
       ENABLE_SIMULCAST: boolean;
       MAX_PEERS?: number;
       FISHJAM_URL: string;
-      FISHJAM_SERVER_TOKEN: string;
+      FISHJAM_SERVER_TOKEN?: string;
+      // TODO[FCE-1283] make this param required
+      FISHJAM_MANAGEMENT_TOKEN?: string;
       ROOM_VIDEO_CODEC: string;
     };
   }
@@ -15,7 +17,8 @@ declare module 'fastify' {
 
 export const configSchema = {
   type: 'object',
-  required: ['PORT', 'ENABLE_SIMULCAST', 'FISHJAM_URL', 'FISHJAM_SERVER_TOKEN'],
+  // TODO[FCE-1283] uncomment FISHJAM_MANAGEMENT_TOKEN
+  required: ['PORT', 'ENABLE_SIMULCAST', 'FISHJAM_URL' /*'FISHJAM_MANAGEMENT_TOKEN'*/],
   properties: {
     PORT: {
       type: 'string',
@@ -41,6 +44,10 @@ export const configSchema = {
       default: 'http://localhost:5002',
     },
     FISHJAM_SERVER_TOKEN: {
+      type: 'string',
+      default: 'development',
+    },
+    FISHJAM_MANAGEMENT_TOKEN: {
       type: 'string',
       default: 'development',
     },

--- a/examples/room-manager/src/config.ts
+++ b/examples/room-manager/src/config.ts
@@ -40,11 +40,11 @@ export const configSchema = {
     },
     FISHJAM_SERVER_TOKEN: {
       type: 'string',
-      default: 'development',
+      default: 'development1',
     },
     FISHJAM_MANAGEMENT_TOKEN: {
       type: 'string',
-      default: 'development',
+      default: undefined,
     },
     ROOM_VIDEO_CODEC: {
       type: 'string',

--- a/examples/room-manager/src/config.ts
+++ b/examples/room-manager/src/config.ts
@@ -40,7 +40,7 @@ export const configSchema = {
     },
     FISHJAM_SERVER_TOKEN: {
       type: 'string',
-      default: 'development1',
+      default: undefined,
     },
     FISHJAM_MANAGEMENT_TOKEN: {
       type: 'string',

--- a/examples/room-manager/src/plugins/fishjam.ts
+++ b/examples/room-manager/src/plugins/fishjam.ts
@@ -27,7 +27,7 @@ export const fishjamPlugin = fastifyPlugin(async (fastify: FastifyInstance): Pro
 
   const fishjamClient = new FishjamClient({
     fishjamUrl: fastify.config.FISHJAM_URL,
-    managementToken: fastify.config.FISHJAM_SERVER_TOKEN,
+    managementToken: fastify.config.FISHJAM_MANAGEMENT_TOKEN ?? fastify.config.FISHJAM_SERVER_TOKEN ?? '',
   });
 
   const peerNameToAccessMap = new Map<string, PeerAccessData>();

--- a/examples/room-manager/src/plugins/fishjam.ts
+++ b/examples/room-manager/src/plugins/fishjam.ts
@@ -27,7 +27,7 @@ export const fishjamPlugin = fastifyPlugin(async (fastify: FastifyInstance): Pro
 
   const fishjamClient = new FishjamClient({
     fishjamUrl: fastify.config.FISHJAM_URL,
-    managementToken: fastify.config.FISHJAM_MANAGEMENT_TOKEN ?? fastify.config.FISHJAM_SERVER_TOKEN ?? '',
+    managementToken: fastify.config.FISHJAM_MANAGEMENT_TOKEN ?? fastify.config.FISHJAM_SERVER_TOKEN ?? 'development',
   });
 
   const peerNameToAccessMap = new Map<string, PeerAccessData>();

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -18,7 +18,7 @@ export class FishjamClient {
    * ```
    * const fishjamClient = new FishjamClient({
    *   fishjamUrl: fastify.config.FISHJAM_URL,
-   *   managementToken: fastify.config.FISHJAM_SERVER_TOKEN,
+   *   managementToken: fastify.config.FISHJAM_MANAGEMENT_TOKEN,
    * });
    * ```
    */


### PR DESCRIPTION
## Description

Change `FISHJAM_SERVER_TOKEN` into `FISHJAM_MANAGEMENT_TOKEN`. But this time with fallback to old name.

## Motivation and Context

Keep names consistent

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
