### PR TITLE
FCE-982 / don't minify the build output

### DIFF
--- a/packages/js-server-sdk/package.json
+++ b/packages/js-server-sdk/package.json
@@ -44,7 +44,7 @@
       "fishjam-openapi",
       "fishjam-proto"
     ],
-    "minify": true,
+    "minify": false,
     "format": [
       "cjs",
       "esm"


### PR DESCRIPTION
## Description

Disable `minify` option to make debugging easier.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
