### PR TITLE
Add room type property

### DIFF
--- a/examples/room-manager/openapi.yaml
+++ b/examples/room-manager/openapi.yaml
@@ -26,6 +26,16 @@ paths:
           in: query
           name: peerName
           required: true
+        - schema:
+            type: string
+            enum:
+              - full_feature
+              - audio_only
+              - broadcaster
+            default: full_feature
+          in: query
+          name: roomType
+          required: false
       responses:
         "200":
           description: Default Response

--- a/examples/room-manager/src/routes/rooms.ts
+++ b/examples/room-manager/src/routes/rooms.ts
@@ -8,9 +8,9 @@ import { httpToWebsocket, removeTrailingSlash } from '../utils';
 export async function rooms(fastify: FastifyInstance) {
   await fastify.register(fishjamPlugin);
 
-  const getRoomAccessHandler = async (roomName: string, peerName: string, res: FastifyReply) => {
+  const getRoomAccessHandler = async (params: GetPeerAccessQueryParams, res: FastifyReply) => {
     try {
-      const accessData = await fastify.fishjam.getPeerAccess(roomName, peerName);
+      const accessData = await fastify.fishjam.getPeerAccess(params.roomName, params.roomName, params.roomType);
       const url = httpToWebsocket(fastify.config.FISHJAM_URL);
 
       // When creating a URL object from a URL without a path (e.g., `http://localhost:5002`),
@@ -28,6 +28,6 @@ export async function rooms(fastify: FastifyInstance) {
   fastify.get<{ Querystring: GetPeerAccessQueryParams }, unknown>(
     '/',
     { schema: queryStringPeerEndpointSchema },
-    (req, res) => getRoomAccessHandler(req.query.roomName, req.query.peerName, res)
+    (req, res) => getRoomAccessHandler(req.query, res)
   );
 }

--- a/examples/room-manager/src/schema.ts
+++ b/examples/room-manager/src/schema.ts
@@ -1,4 +1,4 @@
-import { Peer } from '@fishjam-cloud/js-server-sdk';
+import { Peer, type RoomConfigRoomTypeEnum } from '@fishjam-cloud/js-server-sdk';
 import { FastifySchema } from 'fastify';
 import S from 'fluent-json-schema';
 
@@ -12,6 +12,7 @@ export interface User {
 export interface GetPeerAccessQueryParams {
   roomName: string;
   peerName: string;
+  roomType: RoomConfigRoomTypeEnum;
 }
 
 export interface PeerAccessData {
@@ -33,7 +34,15 @@ const errorResponse410 = S.object()
 
 const errorResponse500 = errorResponse410.prop('cause', S.string());
 
-const parameterSchema = S.object().prop('roomName', S.string().required()).prop('peerName', S.string().required());
+const parameterSchema = S.object()
+  .prop('roomName', S.string().required())
+  .prop('peerName', S.string().required())
+  .prop(
+    'roomType',
+    S.string()
+      .enum(['full_feature', 'audio_only', 'broadcaster'] satisfies RoomConfigRoomTypeEnum[])
+      .default('full_feature')
+  );
 
 export const basePeerEndpointSchema: FastifySchema = {
   querystring: parameterSchema,

--- a/packages/js-server-sdk/src/index.ts
+++ b/packages/js-server-sdk/src/index.ts
@@ -1,4 +1,10 @@
-export { PeerStatus, RoomConfig, PeerOptions, RoomConfigVideoCodecEnum } from '@fishjam-cloud/fishjam-openapi';
+export {
+  PeerStatus,
+  RoomConfig,
+  PeerOptions,
+  RoomConfigVideoCodecEnum,
+  RoomConfigRoomTypeEnum,
+} from '@fishjam-cloud/fishjam-openapi';
 export { FishjamWSNotifier } from './ws_notifier';
 export type { CloseEventHandler, ErrorEventHandler, NotificationEvents, ExpectedEvents } from './ws_notifier';
 export { FishjamClient } from './client';


### PR DESCRIPTION
## Description

Allows to create `audio_only` and `broadcaster` type rooms in the Room Manager.
Exports the room type enum.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
