### PR TITLE
Fix type errors

### DIFF
--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { RoomApi, PeerOptions, ViewerApi, RoomConfigRoomTypeEnum } from '@fishjam-cloud/fishjam-openapi';
-import { FishjamConfig, PeerId, Room, RoomId, Peer, RoomConfig } from './types';
+import { FishjamConfig, PeerId, Room, RoomId, Peer, RoomOptions } from './types';
 import { mapException } from './exceptions/mapper';
 
 /**
@@ -37,7 +37,7 @@ export class FishjamClient {
   /**
    * Create a new room. All peers connected to the same room will be able to send/receive streams to each other.
    */
-  async createRoom(config: RoomConfig = {}): Promise<Room> {
+  async createRoom(config: RoomOptions = {}): Promise<Room> {
     try {
       // TODO: remove after changing type broadcaster to livestream in Fishjam
       const parsedRoomType = config.roomType == 'livestream' ? RoomConfigRoomTypeEnum.Broadcaster : config.roomType;

--- a/packages/js-server-sdk/src/types.ts
+++ b/packages/js-server-sdk/src/types.ts
@@ -1,5 +1,5 @@
-import { Peer as OpenApiPeer, RoomConfigRoomTypeEnum } from '@fishjam-cloud/fishjam-openapi';
-import { RoomConfig as FishjamRoomConfig } from '@fishjam-cloud/fishjam-openapi';
+import { Peer as OpenApiPeer, RoomConfigRoomTypeEnum, RoomConfigVideoCodecEnum } from '@fishjam-cloud/fishjam-openapi';
+
 // branded types are useful for restricting where given value can be passed
 declare const brand: unique symbol;
 /**
@@ -22,7 +22,7 @@ export type Peer = Omit<OpenApiPeer, 'id'> & { id: PeerId };
 export type Room = {
   id: RoomId;
   peers: Peer[];
-  config: RoomConfig;
+  config: RoomOptions;
 };
 
 export type FishjamConfig = {
@@ -30,4 +30,35 @@ export type FishjamConfig = {
   managementToken: string;
 };
 
-export type RoomConfig = Omit<FishjamRoomConfig, 'roomType'> & { roomType?: RoomConfigRoomTypeEnum | 'livestream' };
+export type RoomOptions = {
+  /**
+   * Maximum amount of peers allowed into the room
+   * @type {number}
+   */
+  maxPeers?: number | null;
+  /**
+   * Duration (in seconds) after which the peer will be removed if it is disconnected. If not provided, this feature is disabled.
+   * @type {number}
+   */
+  peerDisconnectedTimeout?: number | null;
+  /**
+   * Duration (in seconds) after which the room will be removed if no peers are connected. If not provided, this feature is disabled.
+   * @type {number}
+   */
+  peerlessPurgeTimeout?: number | null;
+  /**
+   * The use-case of the room. If not provided, this defaults to full_feature.
+   * @type {string}
+   */
+  roomType?: RoomConfigRoomTypeEnum | 'livestream';
+  /**
+   * Enforces video codec for each peer in the room
+   * @type {string}
+   */
+  videoCodec?: RoomConfigVideoCodecEnum | null;
+  /**
+   * URL where Fishjam notifications will be sent
+   * @type {string}
+   */
+  webhookUrl?: string | null;
+};


### PR DESCRIPTION
## Description

Fixes type error in docs
Task to remove it after updating Fishjam: https://linear.app/swmansion/issue/FCE-1583/remove-roomoptions-type-from-js-server-sdk-after-updating-room-type-in

## Motivation and Context

Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
