### PR TITLE
FCE-1283 remove server token leftovers

### DIFF
--- a/examples/room-manager/src/config.ts
+++ b/examples/room-manager/src/config.ts
@@ -33,7 +33,7 @@ export const configSchema = {
     },
     FISHJAM_MANAGEMENT_TOKEN: {
       type: 'string',
-      default: undefined,
+      default: 'development',
     },
     ROOM_VIDEO_CODEC: {
       type: 'string',

--- a/examples/room-manager/src/config.ts
+++ b/examples/room-manager/src/config.ts
@@ -5,9 +5,7 @@ declare module 'fastify' {
       ENABLE_SIMULCAST: boolean;
       MAX_PEERS?: number;
       FISHJAM_URL: string;
-      FISHJAM_SERVER_TOKEN?: string;
-      // TODO[FCE-1283] make this param required
-      FISHJAM_MANAGEMENT_TOKEN?: string;
+      FISHJAM_MANAGEMENT_TOKEN: string;
       ROOM_VIDEO_CODEC: string;
     };
   }
@@ -15,8 +13,7 @@ declare module 'fastify' {
 
 export const configSchema = {
   type: 'object',
-  // TODO[FCE-1283] uncomment FISHJAM_MANAGEMENT_TOKEN
-  required: ['PORT', 'ENABLE_SIMULCAST', 'FISHJAM_URL' /*'FISHJAM_MANAGEMENT_TOKEN'*/],
+  required: ['PORT', 'ENABLE_SIMULCAST', 'FISHJAM_URL', 'FISHJAM_MANAGEMENT_TOKEN'],
   properties: {
     PORT: {
       type: 'string',
@@ -33,10 +30,6 @@ export const configSchema = {
     FISHJAM_URL: {
       type: 'string',
       default: 'http://localhost:5002',
-    },
-    FISHJAM_SERVER_TOKEN: {
-      type: 'string',
-      default: undefined,
     },
     FISHJAM_MANAGEMENT_TOKEN: {
       type: 'string',

--- a/examples/room-manager/src/plugins/fishjam.ts
+++ b/examples/room-manager/src/plugins/fishjam.ts
@@ -31,7 +31,7 @@ export const fishjamPlugin = fastifyPlugin(async (fastify: FastifyInstance): Pro
 
   const fishjamClient = new FishjamClient({
     fishjamUrl: fastify.config.FISHJAM_URL,
-    managementToken: fastify.config.FISHJAM_MANAGEMENT_TOKEN ?? fastify.config.FISHJAM_SERVER_TOKEN ?? 'development',
+    managementToken: fastify.config.FISHJAM_MANAGEMENT_TOKEN ?? 'development',
   });
 
   const peerNameToAccessMap = new Map<string, PeerAccessData>();


### PR DESCRIPTION
## Description

Remove stale and unsupported SERVER_TOKEN config property. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
