### PR TITLE
Fix agent notifications

### DIFF
--- a/examples/transcription/tsconfig.json
+++ b/examples/transcription/tsconfig.json
@@ -8,6 +8,6 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "noEmit": true,
+    "noEmit": true
   }
 }

--- a/packages/js-server-sdk/src/agent.ts
+++ b/packages/js-server-sdk/src/agent.ts
@@ -49,6 +49,7 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
 
     this.client = new WebSocket(websocketUrl);
 
+    this.client.binaryType = 'arraybuffer';
     this.client.onerror = (message) => onError(message);
     this.client.onclose = (message) => onClose(message.code, message.reason);
     this.client.onmessage = (message) => this.dispatchNotification(message);
@@ -94,7 +95,8 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
 
   private dispatchNotification(message: MessageEvent) {
     try {
-      const decodedMessage = AgentResponse.decode(message.data);
+      const data = new Uint8Array(message.data);
+      const decodedMessage = AgentResponse.decode(data);
       const [notification, msg] = Object.entries(decodedMessage).find(([_k, v]) => v)!;
 
       if (!this.isExpectedEvent(notification)) return;


### PR DESCRIPTION
## Description

# Closes FCE-1933

WebSocket returns either `ArrayBuffer` or `Blob` (https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/message_even); on the other hand, the `decode` function needs `BinaryReader` or `Uint8Array`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
