### PR TITLE
FCE-2025 add audio only livestream prop

### DIFF
--- a/packages/fishjam-openapi/src/generated/api.ts
+++ b/packages/fishjam-openapi/src/generated/api.ts
@@ -367,7 +367,8 @@ export const RoomConfigRoomTypeEnum = {
     AudioOnly: 'audio_only',
     Broadcaster: 'broadcaster',
     Livestream: 'livestream',
-    Conference: 'conference'
+    Conference: 'conference',
+    AudioOnlyLivestream: 'audio_only_livestream'
 } as const;
 
 export type RoomConfigRoomTypeEnum = typeof RoomConfigRoomTypeEnum[keyof typeof RoomConfigRoomTypeEnum];


### PR DESCRIPTION
## Description

Adds audio only livestream type.

## Motivation and Context

Allows for creating audio only livestreams.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
