### PR TITLE
FCE-2978 remove track image event

### DIFF
--- a/examples/multimodal/src/service/multimodal.ts
+++ b/examples/multimodal/src/service/multimodal.ts
@@ -80,7 +80,6 @@ export class MultimodalService {
       this.videoTracks.set(message.roomId, new Set());
 
       agent.on('trackData', (msg) => this.handleTrackData(msg));
-      agent.on('trackImage', (msg) => this.handleTrackImage(message.roomId, msg));
 
       this.startImageCapture(message.roomId);
 
@@ -202,16 +201,19 @@ export class MultimodalService {
   }
 
   private startImageCapture(roomId: RoomId) {
-    const interval = setInterval(() => {
+    const interval = setInterval(async () => {
       const agentState = this.agents.get(roomId);
       const tracks = this.videoTracks.get(roomId);
 
       if (!agentState || !tracks || tracks.size === 0) return;
 
-      for (const trackId of tracks) {
-        console.log('Sending image capture request for track', trackId);
-        agentState.agent.captureImage(trackId);
-      }
+      await Promise.all(
+        Array.from(tracks).map(async (trackId) => {
+          console.log('Sending image capture request for track', trackId);
+          const image = await agentState.agent.captureImage(trackId);
+          this.handleTrackImage(roomId, image);
+        })
+      );
     }, CAPTURE_INTERVAL_MS);
 
     this.captureIntervals.set(roomId, interval);

--- a/examples/multimodal/src/service/multimodal.ts
+++ b/examples/multimodal/src/service/multimodal.ts
@@ -207,7 +207,7 @@ export class MultimodalService {
 
       if (!agentState || !tracks || tracks.size === 0) return;
 
-      await Promise.all(
+      await Promise.allSettled(
         Array.from(tracks).map(async (trackId) => {
           console.log('Sending image capture request for track', trackId);
           const image = await agentState.agent.captureImage(trackId);

--- a/packages/js-server-sdk/src/agent.ts
+++ b/packages/js-server-sdk/src/agent.ts
@@ -46,7 +46,7 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
 
   private resolveConnectionPromise: ((value: void | PromiseLike<void>) => void) | null = null;
   private readonly connectionPromise: Promise<void>;
-  private readonly pendingCaptures = new Map<string, (image: IncomingTrackImage) => void>();
+  private readonly pendingImageCaptures = new Map<string, (image: IncomingTrackImage) => void>();
 
   constructor(config: FishjamConfig, agentToken: string, callbacks?: AgentCallbacks) {
     super();
@@ -136,11 +136,11 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
   public captureImage(trackId: TrackId, timeoutMs: number = 5000): Promise<IncomingTrackImage> {
     return new Promise<IncomingTrackImage>((resolve, reject) => {
       const timer = setTimeout(() => {
-        this.pendingCaptures.delete(trackId);
+        this.pendingImageCaptures.delete(trackId);
         reject(new Error(`captureImage timed out after 5s for track ${trackId}`));
       }, timeoutMs);
 
-      this.pendingCaptures.set(trackId, (image) => {
+      this.pendingImageCaptures.set(trackId, (image) => {
         clearTimeout(timer);
         resolve(image);
       });
@@ -157,9 +157,9 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
   private handleTrackImageMessage({ trackImage }: AgentResponse) {
     if (!trackImage) return;
 
-    const resolve = this.pendingCaptures.get(trackImage.trackId);
+    const resolve = this.pendingImageCaptures.get(trackImage.trackId);
     if (resolve) {
-      this.pendingCaptures.delete(trackImage.trackId);
+      this.pendingImageCaptures.delete(trackImage.trackId);
       resolve(trackImage);
     }
   }

--- a/packages/js-server-sdk/src/agent.ts
+++ b/packages/js-server-sdk/src/agent.ts
@@ -130,14 +130,15 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
   /**
    * Request a captured image from the given track
    * @param trackId - the track to capture an image from
+   * @param timeoutMs - timeout in milliseconds (default: 5000)
    * @returns a promise that resolves with the captured image data
    */
-  public captureImage(trackId: TrackId): Promise<IncomingTrackImage> {
+  public captureImage(trackId: TrackId, timeoutMs: number = 5000): Promise<IncomingTrackImage> {
     return new Promise<IncomingTrackImage>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingCaptures.delete(trackId);
         reject(new Error(`captureImage timed out after 5s for track ${trackId}`));
-      }, 5000);
+      }, timeoutMs);
 
       this.pendingCaptures.set(trackId, (image) => {
         clearTimeout(timer);

--- a/packages/js-server-sdk/src/agent.ts
+++ b/packages/js-server-sdk/src/agent.ts
@@ -35,6 +35,12 @@ export type AudioCodecParameters = {
 };
 export type TrackId = Brand<string, 'TrackId'>;
 
+type PendingImageCapture = {
+  resolve: (image: IncomingTrackImage) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
 /**
  * @inline
  */
@@ -46,7 +52,7 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
 
   private resolveConnectionPromise: ((value: void | PromiseLike<void>) => void) | null = null;
   private readonly connectionPromise: Promise<void>;
-  private readonly pendingImageCaptures = new Map<string, (image: IncomingTrackImage) => void>();
+  private readonly pendingImageCaptures = new Map<string, PendingImageCapture>();
 
   constructor(config: FishjamConfig, agentToken: string, callbacks?: AgentCallbacks) {
     super();
@@ -58,7 +64,10 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
 
     this.client.binaryType = 'arraybuffer';
 
-    this.client.onclose = (message) => callbacks?.onClose?.(message.code, message.reason);
+    this.client.onclose = (message) => {
+      this.rejectPendingCaptures('WebSocket closed');
+      callbacks?.onClose?.(message.code, message.reason);
+    };
     this.client.onerror = (message) => callbacks?.onError?.(message);
 
     this.client.onmessage = (message) => this.dispatchNotification(message);
@@ -134,34 +143,52 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
    * @returns a promise that resolves with the captured image data
    */
   public captureImage(trackId: TrackId, timeoutMs: number = 5000): Promise<IncomingTrackImage> {
+    if (this.pendingImageCaptures.has(trackId)) {
+      return Promise.reject(new Error(`captureImage already pending for track ${trackId}`));
+    }
+
     return new Promise<IncomingTrackImage>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingImageCaptures.delete(trackId);
-        reject(new Error(`captureImage timed out after 5s for track ${trackId}`));
+        reject(new Error(`captureImage timed out after ${timeoutMs}ms for track ${trackId}`));
       }, timeoutMs);
 
-      this.pendingImageCaptures.set(trackId, (image) => {
-        clearTimeout(timer);
-        resolve(image);
-      });
+      this.pendingImageCaptures.set(trackId, { resolve, reject, timer });
 
       const msg = AgentRequest.encode({ captureImage: { trackId } }).finish();
-      this.client.send(msg);
+
+      try {
+        this.client.send(msg);
+      } catch (error) {
+        clearTimeout(timer);
+        this.pendingImageCaptures.delete(trackId);
+        reject(error);
+      }
     });
   }
 
   public disconnect(): void {
+    this.rejectPendingCaptures('Agent disconnected');
     this.client.close();
   }
 
   private handleTrackImageMessage({ trackImage }: AgentResponse) {
     if (!trackImage) return;
 
-    const resolve = this.pendingImageCaptures.get(trackImage.trackId);
-    if (resolve) {
+    const pending = this.pendingImageCaptures.get(trackImage.trackId);
+    if (pending) {
+      clearTimeout(pending.timer);
       this.pendingImageCaptures.delete(trackImage.trackId);
-      resolve(trackImage);
+      pending.resolve(trackImage);
     }
+  }
+
+  private rejectPendingCaptures(reason: string): void {
+    for (const [trackId, { reject, timer }] of this.pendingImageCaptures) {
+      clearTimeout(timer);
+      reject(new Error(`${reason}: captureImage rejected for track ${trackId}`));
+    }
+    this.pendingImageCaptures.clear();
   }
 
   private dispatchNotification(message: MessageEvent) {

--- a/packages/js-server-sdk/src/agent.ts
+++ b/packages/js-server-sdk/src/agent.ts
@@ -15,7 +15,7 @@ import {
 import { AgentCallbacks, Brand, FishjamConfig, PeerId } from './types';
 import { getFishjamUrl, httpToWebsocket, WithPeerId } from './utils';
 
-const expectedEventsList = ['trackData', 'trackImage'] as const;
+const expectedEventsList = ['trackData'] as const;
 /**
  * @useDeclaredType
  */
@@ -46,6 +46,7 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
 
   private resolveConnectionPromise: ((value: void | PromiseLike<void>) => void) | null = null;
   private readonly connectionPromise: Promise<void>;
+  private readonly pendingCaptures = new Map<string, (image: IncomingTrackImage) => void>();
 
   constructor(config: FishjamConfig, agentToken: string, callbacks?: AgentCallbacks) {
     super();
@@ -128,21 +129,47 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
 
   /**
    * Request a captured image from the given track
+   * @param trackId - the track to capture an image from
+   * @returns a promise that resolves with the captured image data
    */
-  public captureImage(trackId: TrackId): void {
-    const msg = AgentRequest.encode({ captureImage: { trackId: trackId } }).finish();
+  public captureImage(trackId: TrackId): Promise<IncomingTrackImage> {
+    return new Promise<IncomingTrackImage>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingCaptures.delete(trackId);
+        reject(new Error(`captureImage timed out after 5s for track ${trackId}`));
+      }, 5000);
 
-    this.client.send(msg);
+      this.pendingCaptures.set(trackId, (image) => {
+        clearTimeout(timer);
+        resolve(image);
+      });
+
+      const msg = AgentRequest.encode({ captureImage: { trackId } }).finish();
+      this.client.send(msg);
+    });
   }
 
   public disconnect(): void {
     this.client.close();
   }
 
+  private handleTrackImageMessage({ trackImage }: AgentResponse) {
+    if (!trackImage) return;
+
+    const resolve = this.pendingCaptures.get(trackImage.trackId);
+    if (resolve) {
+      this.pendingCaptures.delete(trackImage.trackId);
+      resolve(trackImage);
+    }
+  }
+
   private dispatchNotification(message: MessageEvent) {
     try {
       const data = new Uint8Array(message.data);
       const decodedMessage = AgentResponse.decode(data);
+
+      this.handleTrackImageMessage(decodedMessage);
+
       const [notification, msg] = Object.entries(decodedMessage).find(([_k, v]) => v)!;
 
       if (!this.isExpectedEvent(notification)) return;


### PR DESCRIPTION
## Description

Removes `trackImage` event and moves the image resolving logic to the `captureImage` function.

## Motivation and Context

Right now, you set up a trackImage listener on the agent, then call agent.captureImage().
This feels a bit awkward, as the captureImage could just return the frame instead of void.

## Documentation impact

- [x] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
