### PR TITLE
Export proto types

### DIFF
--- a/examples/multimodal/src/service/multimodal.ts
+++ b/examples/multimodal/src/service/multimodal.ts
@@ -52,7 +52,7 @@ export class MultimodalService {
   }
 
   async handlePeerConnected(message: PeerConnected) {
-    if (message.peerType === 2) return;
+    if (message.peerType === 'agent') return;
 
     console.log('Peer connected: %O', message);
 
@@ -140,7 +140,7 @@ export class MultimodalService {
   }
 
   handleTrackAdded(message: TrackAdded) {
-    if (!message.track || message.track.type !== 1) return;
+    if (!message.track || message.track.type !== 'video') return;
 
     const trackId = message.track.id as TrackId;
     const tracks = this.videoTracks.get(message.roomId);

--- a/packages/fishjam-openapi/openapi.sh
+++ b/packages/fishjam-openapi/openapi.sh
@@ -19,6 +19,6 @@ echo "Generating code for $1...\n"
 
 cd $ROOTDIR \
 && npx @openapitools/openapi-generator-cli generate \
-  -i https://raw.githubusercontent.com/fishjam-cloud/fishjam/refs/heads/$1/openapi.yaml?token=$2 \
+  -i /Users/roznawsk/fjc/fishjam/openapi.yaml \
   -g typescript-axios \
   -o ./src/generated

--- a/packages/fishjam-openapi/openapi.sh
+++ b/packages/fishjam-openapi/openapi.sh
@@ -19,6 +19,6 @@ echo "Generating code for $1...\n"
 
 cd $ROOTDIR \
 && npx @openapitools/openapi-generator-cli generate \
-  -i /Users/roznawsk/fjc/fishjam/openapi.yaml \
+  -i https://raw.githubusercontent.com/fishjam-cloud/fishjam/refs/heads/$1/openapi.yaml?token=$2 \
   -g typescript-axios \
   -o ./src/generated

--- a/packages/js-server-sdk/src/agent.ts
+++ b/packages/js-server-sdk/src/agent.ts
@@ -27,7 +27,6 @@ export type OutgoingTrackData = Omit<NonNullable<AgentRequest_TrackData>, 'peerI
 
 export type AgentTrack = Omit<ProtoTrack, 'id'> & { id: TrackId };
 
-export type TrackType = 'audio' | 'video';
 export type AudioCodecParameters = {
   encoding: 'opus' | 'pcm16';
   sampleRate: 16000 | 24000 | 48000;

--- a/packages/js-server-sdk/src/agent.ts
+++ b/packages/js-server-sdk/src/agent.ts
@@ -141,7 +141,7 @@ export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentE
    * @param timeoutMs - timeout in milliseconds (default: 5000)
    * @returns a promise that resolves with the captured image data
    */
-  public captureImage(trackId: string, timeoutMs: number = 5000): Promise<IncomingTrackImage> {
+  public captureImage(trackId: TrackId, timeoutMs: number = 5000): Promise<IncomingTrackImage> {
     if (this.pendingImageCaptures.has(trackId)) {
       return Promise.reject(new Error(`captureImage already pending for track ${trackId}`));
     }

--- a/packages/js-server-sdk/src/index.ts
+++ b/packages/js-server-sdk/src/index.ts
@@ -34,13 +34,15 @@ export type {
   PeerDisconnected,
   PeerMetadataUpdated,
   PeerCrashed,
-  StreamConnected,
-  StreamDisconnected,
+  StreamerConnected,
+  StreamerDisconnected,
   ViewerConnected,
   ViewerDisconnected,
   TrackAdded,
   TrackRemoved,
   TrackMetadataUpdated,
+  ChannelAdded,
+  ChannelRemoved,
   NotificationEvents,
 } from './notifications';
 export { FishjamAgent } from './agent';

--- a/packages/js-server-sdk/src/index.ts
+++ b/packages/js-server-sdk/src/index.ts
@@ -20,8 +20,6 @@ export {
 export { ServerMessage } from '@fishjam-cloud/fishjam-proto';
 export { FishjamWSNotifier } from './ws_notifier';
 export type {
-  PeerType,
-  TrackType,
   Track,
   ExpectedEvents,
   IgnoredEvents,

--- a/packages/js-server-sdk/src/index.ts
+++ b/packages/js-server-sdk/src/index.ts
@@ -19,7 +19,30 @@ export {
 
 export { ServerMessage } from '@fishjam-cloud/fishjam-proto';
 export { FishjamWSNotifier } from './ws_notifier';
-export type * from './ws_notifier';
+export type {
+  PeerType,
+  TrackType,
+  Track,
+  ExpectedEvents,
+  IgnoredEvents,
+  RoomCreated,
+  RoomDeleted,
+  RoomCrashed,
+  PeerAdded,
+  PeerDeleted,
+  PeerConnected,
+  PeerDisconnected,
+  PeerMetadataUpdated,
+  PeerCrashed,
+  StreamConnected,
+  StreamDisconnected,
+  ViewerConnected,
+  ViewerDisconnected,
+  TrackAdded,
+  TrackRemoved,
+  TrackMetadataUpdated,
+  NotificationEvents,
+} from './notifications';
 export { FishjamAgent } from './agent';
 export type * from './agent';
 export { FishjamClient } from './client';

--- a/packages/js-server-sdk/src/notifications.ts
+++ b/packages/js-server-sdk/src/notifications.ts
@@ -4,19 +4,8 @@ import {
   TrackType as ProtoTrackType,
   Track as ProtoTrack,
 } from '@fishjam-cloud/fishjam-proto';
+import { PeerType, TrackType } from './types';
 import { WithPeerId, WithRoomId } from './utils';
-
-/**
- * Peer type as emitted by {@link FishjamWSNotifier}. Matches the REST API's `PeerType`,
- * with the addition of `'unspecified'` for messages whose peer type is not set on the wire.
- */
-export type PeerType = 'webrtc' | 'agent' | 'vapi' | 'unspecified';
-
-/**
- * Track type as emitted by {@link FishjamWSNotifier}. Matches the REST API's `TrackType`,
- * with the addition of `'unspecified'` for messages whose track type is not set on the wire.
- */
-export type TrackType = 'audio' | 'video' | 'unspecified';
 
 /**
  * Track payload embedded in {@link TrackAdded}, {@link TrackRemoved}, {@link TrackMetadataUpdated}.
@@ -96,7 +85,10 @@ export type IgnoredEvents = (typeof ignoredEventsList)[number];
  */
 type MessageWithIds = WithPeerId<WithRoomId<ServerMessage>>;
 
+/** @inline */
 type WithMappedPeerType<T> = Omit<T, 'peerType'> & { peerType: PeerType };
+
+/** @inline */
 type WithMappedTrack<T> = Omit<T, 'track'> & { track: Track | undefined };
 
 /**

--- a/packages/js-server-sdk/src/notifications.ts
+++ b/packages/js-server-sdk/src/notifications.ts
@@ -1,0 +1,197 @@
+import {
+  ServerMessage,
+  ServerMessage_PeerType,
+  TrackType as ProtoTrackType,
+  Track as ProtoTrack,
+} from '@fishjam-cloud/fishjam-proto';
+import { WithPeerId, WithRoomId } from './utils';
+
+/**
+ * Peer type as emitted by {@link FishjamWSNotifier}. Matches the REST API's `PeerType`,
+ * with the addition of `'unspecified'` for messages whose peer type is not set on the wire.
+ */
+export type PeerType = 'webrtc' | 'agent' | 'vapi' | 'unspecified';
+
+/**
+ * Track type as emitted by {@link FishjamWSNotifier}. Matches the REST API's `TrackType`,
+ * with the addition of `'unspecified'` for messages whose track type is not set on the wire.
+ */
+export type TrackType = 'audio' | 'video' | 'unspecified';
+
+/**
+ * Track payload embedded in {@link TrackAdded}, {@link TrackRemoved}, {@link TrackMetadataUpdated}.
+ */
+export type Track = {
+  id: string;
+  type: TrackType;
+  metadata: string;
+};
+
+const peerTypeMap: Record<ServerMessage_PeerType, PeerType> = {
+  [ServerMessage_PeerType.PEER_TYPE_UNSPECIFIED]: 'unspecified',
+  [ServerMessage_PeerType.PEER_TYPE_WEBRTC]: 'webrtc',
+  [ServerMessage_PeerType.PEER_TYPE_AGENT]: 'agent',
+  [ServerMessage_PeerType.PEER_TYPE_VAPI]: 'vapi',
+  [ServerMessage_PeerType.UNRECOGNIZED]: 'unspecified',
+};
+
+const trackTypeMap: Record<ProtoTrackType, TrackType> = {
+  [ProtoTrackType.TRACK_TYPE_UNSPECIFIED]: 'unspecified',
+  [ProtoTrackType.TRACK_TYPE_VIDEO]: 'video',
+  [ProtoTrackType.TRACK_TYPE_AUDIO]: 'audio',
+  [ProtoTrackType.UNRECOGNIZED]: 'unspecified',
+};
+
+export type ExpectedEvents =
+  | 'roomCreated'
+  | 'roomDeleted'
+  | 'roomCrashed'
+  | 'peerAdded'
+  | 'peerDeleted'
+  | 'peerConnected'
+  | 'peerDisconnected'
+  | 'peerMetadataUpdated'
+  | 'peerCrashed'
+  | 'streamConnected'
+  | 'streamDisconnected'
+  | 'viewerConnected'
+  | 'viewerDisconnected'
+  | 'trackAdded'
+  | 'trackRemoved'
+  | 'trackMetadataUpdated';
+
+/**
+ * `ServerMessage` oneof members that are intentionally NOT emitted to users.
+ * Grouped with a brief rationale so the classification stays reviewable.
+ * Mirrors the Python SDK's `IGNORED_NOTIFICATIONS` partition (FCE-3215).
+ */
+export type IgnoredEvents =
+  // Handshake / request-side — never inbound notifications.
+  | 'authenticated'
+  | 'authRequest'
+  | 'subscribeRequest'
+  | 'subscribeResponse'
+  // Currently unsurfaced server notifications — no consumer demand yet.
+  | 'channelAdded'
+  | 'channelRemoved'
+  | 'trackForwarding'
+  | 'trackForwardingRemoved'
+  | 'vadNotification'
+  | 'streamerConnected'
+  | 'streamerDisconnected'
+  | 'hlsPlayable'
+  | 'hlsUploaded'
+  | 'hlsUploadCrashed'
+  | 'componentCrashed';
+
+export const ignoredEventsList: ReadonlyArray<IgnoredEvents> = [
+  'authenticated',
+  'authRequest',
+  'subscribeRequest',
+  'subscribeResponse',
+  'channelAdded',
+  'channelRemoved',
+  'trackForwarding',
+  'trackForwardingRemoved',
+  'vadNotification',
+  'streamerConnected',
+  'streamerDisconnected',
+  'hlsPlayable',
+  'hlsUploaded',
+  'hlsUploadCrashed',
+  'componentCrashed',
+] as const;
+
+/**
+ * @inline
+ */
+type MessageWithIds = WithPeerId<WithRoomId<ServerMessage>>;
+
+type WithMappedPeerType<T> = Omit<T, 'peerType'> & { peerType: PeerType };
+type WithMappedTrack<T> = Omit<T, 'track'> & { track: Track | undefined };
+
+/**
+ * @inline
+ */
+export type Notifications = {
+  roomCreated: NonNullable<MessageWithIds['roomCreated']>;
+  roomDeleted: NonNullable<MessageWithIds['roomDeleted']>;
+  roomCrashed: NonNullable<MessageWithIds['roomCrashed']>;
+  peerAdded: WithMappedPeerType<NonNullable<MessageWithIds['peerAdded']>>;
+  peerDeleted: WithMappedPeerType<NonNullable<MessageWithIds['peerDeleted']>>;
+  peerConnected: WithMappedPeerType<NonNullable<MessageWithIds['peerConnected']>>;
+  peerDisconnected: WithMappedPeerType<NonNullable<MessageWithIds['peerDisconnected']>>;
+  peerMetadataUpdated: WithMappedPeerType<NonNullable<MessageWithIds['peerMetadataUpdated']>>;
+  peerCrashed: WithMappedPeerType<NonNullable<MessageWithIds['peerCrashed']>>;
+  streamConnected: NonNullable<MessageWithIds['streamConnected']>;
+  streamDisconnected: NonNullable<MessageWithIds['streamDisconnected']>;
+  viewerConnected: NonNullable<MessageWithIds['viewerConnected']>;
+  viewerDisconnected: NonNullable<MessageWithIds['viewerDisconnected']>;
+  trackAdded: WithMappedTrack<NonNullable<MessageWithIds['trackAdded']>>;
+  trackRemoved: WithMappedTrack<NonNullable<MessageWithIds['trackRemoved']>>;
+  trackMetadataUpdated: WithMappedTrack<NonNullable<MessageWithIds['trackMetadataUpdated']>>;
+};
+
+export type RoomCreated = Notifications['roomCreated'];
+export type RoomDeleted = Notifications['roomDeleted'];
+export type RoomCrashed = Notifications['roomCrashed'];
+export type PeerAdded = Notifications['peerAdded'];
+export type PeerDeleted = Notifications['peerDeleted'];
+export type PeerConnected = Notifications['peerConnected'];
+export type PeerDisconnected = Notifications['peerDisconnected'];
+export type PeerMetadataUpdated = Notifications['peerMetadataUpdated'];
+export type PeerCrashed = Notifications['peerCrashed'];
+export type StreamConnected = Notifications['streamConnected'];
+export type StreamDisconnected = Notifications['streamDisconnected'];
+export type ViewerConnected = Notifications['viewerConnected'];
+export type ViewerDisconnected = Notifications['viewerDisconnected'];
+export type TrackAdded = Notifications['trackAdded'];
+export type TrackRemoved = Notifications['trackRemoved'];
+export type TrackMetadataUpdated = Notifications['trackMetadataUpdated'];
+
+export const expectedEventsList: ReadonlyArray<ExpectedEvents> = [
+  'roomCreated',
+  'roomDeleted',
+  'roomCrashed',
+  'peerAdded',
+  'peerDeleted',
+  'peerConnected',
+  'peerDisconnected',
+  'peerMetadataUpdated',
+  'peerCrashed',
+  'streamConnected',
+  'streamDisconnected',
+  'viewerConnected',
+  'viewerDisconnected',
+  'trackAdded',
+  'trackRemoved',
+  'trackMetadataUpdated',
+] as const;
+
+export const peerEventsWithPeerType = new Set<ExpectedEvents>([
+  'peerAdded',
+  'peerDeleted',
+  'peerConnected',
+  'peerDisconnected',
+  'peerMetadataUpdated',
+  'peerCrashed',
+]);
+
+export const trackEvents = new Set<ExpectedEvents>(['trackAdded', 'trackRemoved', 'trackMetadataUpdated']);
+
+const mapTrack = (track: ProtoTrack | undefined): Track | undefined =>
+  track && { id: track.id, type: trackTypeMap[track.type], metadata: track.metadata };
+
+export const mapNotification = (event: ExpectedEvents, msg: unknown): unknown => {
+  if (peerEventsWithPeerType.has(event)) {
+    const peerMsg = msg as { peerType: ServerMessage_PeerType };
+    return { ...peerMsg, peerType: peerTypeMap[peerMsg.peerType] };
+  }
+  if (trackEvents.has(event)) {
+    const trackMsg = msg as { track: ProtoTrack | undefined };
+    return { ...trackMsg, track: mapTrack(trackMsg.track) };
+  }
+  return msg;
+};
+
+export type NotificationEvents = { [K in ExpectedEvents]: (message: Notifications[K]) => void };

--- a/packages/js-server-sdk/src/notifications.ts
+++ b/packages/js-server-sdk/src/notifications.ts
@@ -42,65 +42,54 @@ const trackTypeMap: Record<ProtoTrackType, TrackType> = {
   [ProtoTrackType.UNRECOGNIZED]: 'unspecified',
 };
 
-export type ExpectedEvents =
-  | 'roomCreated'
-  | 'roomDeleted'
-  | 'roomCrashed'
-  | 'peerAdded'
-  | 'peerDeleted'
-  | 'peerConnected'
-  | 'peerDisconnected'
-  | 'peerMetadataUpdated'
-  | 'peerCrashed'
-  | 'streamConnected'
-  | 'streamDisconnected'
-  | 'viewerConnected'
-  | 'viewerDisconnected'
-  | 'trackAdded'
-  | 'trackRemoved'
-  | 'trackMetadataUpdated';
+export const expectedEventsList = [
+  'roomCreated',
+  'roomDeleted',
+  'roomCrashed',
+  'peerAdded',
+  'peerDeleted',
+  'peerConnected',
+  'peerDisconnected',
+  'peerMetadataUpdated',
+  'peerCrashed',
+  'streamerConnected',
+  'streamerDisconnected',
+  'viewerConnected',
+  'viewerDisconnected',
+  'trackAdded',
+  'trackRemoved',
+  'trackMetadataUpdated',
+  'channelAdded',
+  'channelRemoved',
+] as const;
+
+export type ExpectedEvents = (typeof expectedEventsList)[number];
 
 /**
  * `ServerMessage` oneof members that are intentionally NOT emitted to users.
  * Grouped with a brief rationale so the classification stays reviewable.
  * Mirrors the Python SDK's `IGNORED_NOTIFICATIONS` partition (FCE-3215).
  */
-export type IgnoredEvents =
+export const ignoredEventsList = [
   // Handshake / request-side — never inbound notifications.
-  | 'authenticated'
-  | 'authRequest'
-  | 'subscribeRequest'
-  | 'subscribeResponse'
-  // Currently unsurfaced server notifications — no consumer demand yet.
-  | 'channelAdded'
-  | 'channelRemoved'
-  | 'trackForwarding'
-  | 'trackForwardingRemoved'
-  | 'vadNotification'
-  | 'streamerConnected'
-  | 'streamerDisconnected'
-  | 'hlsPlayable'
-  | 'hlsUploaded'
-  | 'hlsUploadCrashed'
-  | 'componentCrashed';
-
-export const ignoredEventsList: ReadonlyArray<IgnoredEvents> = [
   'authenticated',
   'authRequest',
   'subscribeRequest',
   'subscribeResponse',
-  'channelAdded',
-  'channelRemoved',
+  // Currently unsurfaced server notifications — no consumer demand yet.
   'trackForwarding',
   'trackForwardingRemoved',
   'vadNotification',
-  'streamerConnected',
-  'streamerDisconnected',
+  // Deprecated
+  'streamConnected',
+  'streamDisconnected',
   'hlsPlayable',
   'hlsUploaded',
   'hlsUploadCrashed',
   'componentCrashed',
 ] as const;
+
+export type IgnoredEvents = (typeof ignoredEventsList)[number];
 
 /**
  * @inline
@@ -123,13 +112,15 @@ export type Notifications = {
   peerDisconnected: WithMappedPeerType<NonNullable<MessageWithIds['peerDisconnected']>>;
   peerMetadataUpdated: WithMappedPeerType<NonNullable<MessageWithIds['peerMetadataUpdated']>>;
   peerCrashed: WithMappedPeerType<NonNullable<MessageWithIds['peerCrashed']>>;
-  streamConnected: NonNullable<MessageWithIds['streamConnected']>;
-  streamDisconnected: NonNullable<MessageWithIds['streamDisconnected']>;
+  streamerConnected: NonNullable<MessageWithIds['streamerConnected']>;
+  streamerDisconnected: NonNullable<MessageWithIds['streamerDisconnected']>;
   viewerConnected: NonNullable<MessageWithIds['viewerConnected']>;
   viewerDisconnected: NonNullable<MessageWithIds['viewerDisconnected']>;
   trackAdded: WithMappedTrack<NonNullable<MessageWithIds['trackAdded']>>;
   trackRemoved: WithMappedTrack<NonNullable<MessageWithIds['trackRemoved']>>;
   trackMetadataUpdated: WithMappedTrack<NonNullable<MessageWithIds['trackMetadataUpdated']>>;
+  channelAdded: NonNullable<MessageWithIds['channelAdded']>;
+  channelRemoved: NonNullable<MessageWithIds['channelRemoved']>;
 };
 
 export type RoomCreated = Notifications['roomCreated'];
@@ -141,32 +132,15 @@ export type PeerConnected = Notifications['peerConnected'];
 export type PeerDisconnected = Notifications['peerDisconnected'];
 export type PeerMetadataUpdated = Notifications['peerMetadataUpdated'];
 export type PeerCrashed = Notifications['peerCrashed'];
-export type StreamConnected = Notifications['streamConnected'];
-export type StreamDisconnected = Notifications['streamDisconnected'];
+export type StreamerConnected = Notifications['streamerConnected'];
+export type StreamerDisconnected = Notifications['streamerDisconnected'];
 export type ViewerConnected = Notifications['viewerConnected'];
 export type ViewerDisconnected = Notifications['viewerDisconnected'];
 export type TrackAdded = Notifications['trackAdded'];
 export type TrackRemoved = Notifications['trackRemoved'];
 export type TrackMetadataUpdated = Notifications['trackMetadataUpdated'];
-
-export const expectedEventsList: ReadonlyArray<ExpectedEvents> = [
-  'roomCreated',
-  'roomDeleted',
-  'roomCrashed',
-  'peerAdded',
-  'peerDeleted',
-  'peerConnected',
-  'peerDisconnected',
-  'peerMetadataUpdated',
-  'peerCrashed',
-  'streamConnected',
-  'streamDisconnected',
-  'viewerConnected',
-  'viewerDisconnected',
-  'trackAdded',
-  'trackRemoved',
-  'trackMetadataUpdated',
-] as const;
+export type ChannelAdded = Notifications['channelAdded'];
+export type ChannelRemoved = Notifications['channelRemoved'];
 
 export const peerEventsWithPeerType = new Set<ExpectedEvents>([
   'peerAdded',

--- a/packages/js-server-sdk/src/types.ts
+++ b/packages/js-server-sdk/src/types.ts
@@ -1,4 +1,9 @@
-import { Peer as OpenApiPeer, RoomConfig } from '@fishjam-cloud/fishjam-openapi';
+import {
+  Peer as OpenApiPeer,
+  PeerType as OpenApiPeerType,
+  RoomConfig,
+  TrackType as OpenApiTrackType,
+} from '@fishjam-cloud/fishjam-openapi';
 
 // branded types are useful for restricting where given value can be passed
 declare const brand: unique symbol;
@@ -24,6 +29,18 @@ export type PeerId = Brand<string, 'PeerId'>;
 export type StreamId = Brand<string, 'StreamId'>;
 
 export type Peer = Omit<OpenApiPeer, 'id'> & { id: PeerId };
+
+/**
+ * Peer type as emitted by {@link FishjamWSNotifier}. Matches the REST API's `PeerType`,
+ * with the addition of `'unspecified'` for messages whose peer type is not set on the wire.
+ */
+export type PeerType = OpenApiPeerType | 'unspecified';
+
+/**
+ * Track type as emitted by {@link FishjamWSNotifier}. Matches the REST API's `TrackType`,
+ * with the addition of `'unspecified'` for messages whose track type is not set on the wire.
+ */
+export type TrackType = OpenApiTrackType | 'unspecified';
 
 export type Room = {
   id: RoomId;

--- a/packages/js-server-sdk/src/ws_notifier.ts
+++ b/packages/js-server-sdk/src/ws_notifier.ts
@@ -1,73 +1,9 @@
 import TypedEmitter from 'typed-emitter';
 import { EventEmitter } from 'events';
 import { CloseEventHandler, ErrorEventHandler, FishjamConfig } from './types';
-import { getFishjamUrl, httpToWebsocket, WithPeerId, WithRoomId } from './utils';
+import { getFishjamUrl, httpToWebsocket } from './utils';
 import { ServerMessage, ServerMessage_EventType } from '@fishjam-cloud/fishjam-proto';
-
-export type ExpectedEvents =
-  | 'roomCreated'
-  | 'roomDeleted'
-  | 'roomCrashed'
-  | 'peerAdded'
-  | 'peerDeleted'
-  | 'peerConnected'
-  | 'peerDisconnected'
-  | 'peerMetadataUpdated'
-  | 'peerCrashed'
-  | 'streamConnected'
-  | 'streamDisconnected'
-  | 'viewerConnected'
-  | 'viewerDisconnected'
-  | 'trackAdded'
-  | 'trackRemoved'
-  | 'trackMetadataUpdated';
-
-/**
- * @inline
- */
-type MessageWithIds = WithPeerId<WithRoomId<ServerMessage>>;
-/**
- * @inline
- */
-type Notifications = { [K in ExpectedEvents]: NonNullable<MessageWithIds[K]> };
-
-export type RoomCreated = Notifications['roomCreated'];
-export type RoomDeleted = Notifications['roomDeleted'];
-export type RoomCrashed = Notifications['roomCrashed'];
-export type PeerAdded = Notifications['peerAdded'];
-export type PeerDeleted = Notifications['peerDeleted'];
-export type PeerConnected = Notifications['peerConnected'];
-export type PeerDisconnected = Notifications['peerDisconnected'];
-export type PeerMetadataUpdated = Notifications['peerMetadataUpdated'];
-export type PeerCrashed = Notifications['peerCrashed'];
-export type StreamConnected = Notifications['streamConnected'];
-export type StreamDisconnected = Notifications['streamDisconnected'];
-export type ViewerConnected = Notifications['viewerConnected'];
-export type ViewerDisconnected = Notifications['viewerDisconnected'];
-export type TrackAdded = Notifications['trackAdded'];
-export type TrackRemoved = Notifications['trackRemoved'];
-export type TrackMetadataUpdated = Notifications['trackMetadataUpdated'];
-
-const expectedEventsList: ReadonlyArray<ExpectedEvents> = [
-  'roomCreated',
-  'roomDeleted',
-  'roomCrashed',
-  'peerAdded',
-  'peerDeleted',
-  'peerConnected',
-  'peerDisconnected',
-  'peerMetadataUpdated',
-  'peerCrashed',
-  'streamConnected',
-  'streamDisconnected',
-  'viewerConnected',
-  'viewerDisconnected',
-  'trackAdded',
-  'trackRemoved',
-  'trackMetadataUpdated',
-] as const;
-
-export type NotificationEvents = { [K in ExpectedEvents]: (message: NonNullable<MessageWithIds[K]>) => void };
+import { ExpectedEvents, NotificationEvents, expectedEventsList, mapNotification } from './notifications';
 
 /**
  * Notifier object that can be used to get notified about various events related to the Fishjam App.
@@ -100,7 +36,9 @@ export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<N
 
       if (!this.isExpectedEvent(notification)) return;
 
-      this.emit(notification, msg);
+      // TS can't narrow per-event through Object.entries, so widen emit's signature at the call site.
+      const emit = this.emit as (event: ExpectedEvents, message: unknown) => boolean;
+      emit(notification, mapNotification(notification, msg));
     } catch (e) {
       console.error("Couldn't decode websocket server message", e, message);
     }

--- a/packages/js-server-sdk/tests/notifications.test.ts
+++ b/packages/js-server-sdk/tests/notifications.test.ts
@@ -42,13 +42,15 @@ describe('notifications module', () => {
     expectTypeOf<SDK.PeerCrashed>().toEqualTypeOf<Notifications['peerCrashed']>();
     expectTypeOf<SDK.RoomDeleted>().toEqualTypeOf<Notifications['roomDeleted']>();
     expectTypeOf<SDK.RoomCrashed>().toEqualTypeOf<Notifications['roomCrashed']>();
-    expectTypeOf<SDK.StreamConnected>().toEqualTypeOf<Notifications['streamConnected']>();
-    expectTypeOf<SDK.StreamDisconnected>().toEqualTypeOf<Notifications['streamDisconnected']>();
+    expectTypeOf<SDK.StreamerConnected>().toEqualTypeOf<Notifications['streamerConnected']>();
+    expectTypeOf<SDK.StreamerDisconnected>().toEqualTypeOf<Notifications['streamerDisconnected']>();
     expectTypeOf<SDK.ViewerConnected>().toEqualTypeOf<Notifications['viewerConnected']>();
     expectTypeOf<SDK.ViewerDisconnected>().toEqualTypeOf<Notifications['viewerDisconnected']>();
     expectTypeOf<SDK.TrackAdded>().toEqualTypeOf<Notifications['trackAdded']>();
     expectTypeOf<SDK.TrackRemoved>().toEqualTypeOf<Notifications['trackRemoved']>();
     expectTypeOf<SDK.TrackMetadataUpdated>().toEqualTypeOf<Notifications['trackMetadataUpdated']>();
+    expectTypeOf<SDK.ChannelAdded>().toEqualTypeOf<Notifications['channelAdded']>();
+    expectTypeOf<SDK.ChannelRemoved>().toEqualTypeOf<Notifications['channelRemoved']>();
   });
 
   it('peerEventsWithPeerType covers all ExpectedEvents with a peerType field', () => {

--- a/packages/js-server-sdk/tests/notifications.test.ts
+++ b/packages/js-server-sdk/tests/notifications.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import type { ServerMessage } from '@fishjam-cloud/fishjam-proto';
+import { expectedEventsList, ignoredEventsList, peerEventsWithPeerType, trackEvents } from '../src/notifications';
+import type { ExpectedEvents, IgnoredEvents, Notifications } from '../src/notifications';
+import type * as SDK from '../src';
+
+// 1. Compile-time completeness: every `ServerMessage` oneof must be classified
+//    as either an ExpectedEvents or IgnoredEvents member. If a new oneof is
+//    added, this line fails to compile with the offending name literally in
+//    the error.
+type Unaccounted = Exclude<keyof ServerMessage, ExpectedEvents | IgnoredEvents>;
+const _exhaustive: [Unaccounted] extends [never] ? true : Unaccounted = true as [Unaccounted] extends [never]
+  ? true
+  : Unaccounted;
+void _exhaustive;
+
+// 4. Mapping-set coverage (compile-time): if someone adds a new peerType- or
+//    track-carrying event to ExpectedEvents, the runtime required[] below
+//    will fail to satisfy the computed key set.
+type EventsWithPeerTypeField = {
+  [K in ExpectedEvents]: Notifications[K] extends { peerType: unknown } ? K : never;
+}[ExpectedEvents];
+
+type EventsWithTrackField = {
+  [K in ExpectedEvents]: Notifications[K] extends { track?: unknown } ? K : never;
+}[ExpectedEvents];
+
+describe('notifications module', () => {
+  it('ExpectedEvents and IgnoredEvents are disjoint', () => {
+    const ignored = ignoredEventsList as readonly string[];
+    const overlap = expectedEventsList.filter((e) => ignored.includes(e));
+    expect(overlap).toEqual([]);
+  });
+
+  it('every ExpectedEvents member is surfaced as a named type export', () => {
+    expectTypeOf<SDK.RoomCreated>().toEqualTypeOf<Notifications['roomCreated']>();
+    expectTypeOf<SDK.PeerAdded>().toEqualTypeOf<Notifications['peerAdded']>();
+    expectTypeOf<SDK.PeerDeleted>().toEqualTypeOf<Notifications['peerDeleted']>();
+    expectTypeOf<SDK.PeerConnected>().toEqualTypeOf<Notifications['peerConnected']>();
+    expectTypeOf<SDK.PeerDisconnected>().toEqualTypeOf<Notifications['peerDisconnected']>();
+    expectTypeOf<SDK.PeerMetadataUpdated>().toEqualTypeOf<Notifications['peerMetadataUpdated']>();
+    expectTypeOf<SDK.PeerCrashed>().toEqualTypeOf<Notifications['peerCrashed']>();
+    expectTypeOf<SDK.RoomDeleted>().toEqualTypeOf<Notifications['roomDeleted']>();
+    expectTypeOf<SDK.RoomCrashed>().toEqualTypeOf<Notifications['roomCrashed']>();
+    expectTypeOf<SDK.StreamConnected>().toEqualTypeOf<Notifications['streamConnected']>();
+    expectTypeOf<SDK.StreamDisconnected>().toEqualTypeOf<Notifications['streamDisconnected']>();
+    expectTypeOf<SDK.ViewerConnected>().toEqualTypeOf<Notifications['viewerConnected']>();
+    expectTypeOf<SDK.ViewerDisconnected>().toEqualTypeOf<Notifications['viewerDisconnected']>();
+    expectTypeOf<SDK.TrackAdded>().toEqualTypeOf<Notifications['trackAdded']>();
+    expectTypeOf<SDK.TrackRemoved>().toEqualTypeOf<Notifications['trackRemoved']>();
+    expectTypeOf<SDK.TrackMetadataUpdated>().toEqualTypeOf<Notifications['trackMetadataUpdated']>();
+  });
+
+  it('peerEventsWithPeerType covers all ExpectedEvents with a peerType field', () => {
+    const required: EventsWithPeerTypeField[] = [
+      'peerAdded',
+      'peerDeleted',
+      'peerConnected',
+      'peerDisconnected',
+      'peerMetadataUpdated',
+      'peerCrashed',
+    ];
+    for (const event of required) {
+      expect(peerEventsWithPeerType.has(event)).toBe(true);
+    }
+  });
+
+  it('trackEvents covers all ExpectedEvents with a track field', () => {
+    const required: EventsWithTrackField[] = ['trackAdded', 'trackRemoved', 'trackMetadataUpdated'];
+    for (const event of required) {
+      expect(trackEvents.has(event)).toBe(true);
+    }
+  });
+});

--- a/packages/js-server-sdk/tests/notifications.test.ts
+++ b/packages/js-server-sdk/tests/notifications.test.ts
@@ -4,7 +4,7 @@ import { expectedEventsList, ignoredEventsList, peerEventsWithPeerType, trackEve
 import type { ExpectedEvents, IgnoredEvents, Notifications } from '../src/notifications';
 import type * as SDK from '../src';
 
-// 1. Compile-time completeness: every `ServerMessage` oneof must be classified
+//    Compile-time completeness: every `ServerMessage` oneof must be classified
 //    as either an ExpectedEvents or IgnoredEvents member. If a new oneof is
 //    added, this line fails to compile with the offending name literally in
 //    the error.
@@ -14,7 +14,7 @@ const _exhaustive: [Unaccounted] extends [never] ? true : Unaccounted = true as 
   : Unaccounted;
 void _exhaustive;
 
-// 4. Mapping-set coverage (compile-time): if someone adds a new peerType- or
+//    Mapping-set coverage (compile-time): if someone adds a new peerType- or
 //    track-carrying event to ExpectedEvents, the runtime required[] below
 //    will fail to satisfy the computed key set.
 type EventsWithPeerTypeField = {

--- a/packages/js-server-sdk/tsconfig.json
+++ b/packages/js-server-sdk/tsconfig.json
@@ -13,9 +13,8 @@
     "declaration": true,
     "moduleResolution": "bundler",
     "forceConsistentCasingInFileNames": true,
-    "rootDir": "./src",
     "outDir": "dist"
   },
-  "exclude": ["node_modules"],
-  "include": ["src/**/*.ts"]
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,5 +7,9 @@
   "themeColor": "#FCF6E7",
   "readme": "none",
   "treatValidationWarningsAsErrors": true,
-  "treatWarningsAsErrors": true
+  "treatWarningsAsErrors": true,
+  "intentionallyNotExported": ["expectedEventsList", "ignoredEventsList"],
+  "packageOptions": {
+    "intentionallyNotExported": ["expectedEventsList", "ignoredEventsList"]
+  }
 }


### PR DESCRIPTION
## Description

Added mapping of proto types to existing types, exported from openapi
`ServerMessage_PeerType` -> `PeerType`
(proto) `TrackType` -> (openapi) `TrackType`

Exposed the `ChannelAdded`, `ChannelRemoved` events
Replacted the deprecated and no longer published by fishjam events `StreamConnected`, `StreamDisconnected` -> `StreamerConnected`, `StreamerDisconnected`

## Motivation and Context

Currently, when using the js-server-sdk WSNotifiter, the user is forced to use magic numbers when comparing peer types, e.g.

```
if (msg.peerType === 2) {} // 1 is webrtc, 2 is agent, 3 is unspecified (webrtc) 
```


## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
