### PR TITLE
FCE-3230 fix ugly type definitions

### DIFF
--- a/packages/js-server-sdk/src/agent.ts
+++ b/packages/js-server-sdk/src/agent.ts
@@ -12,8 +12,8 @@ import {
   TrackType as ProtoTrackType,
   TrackEncoding,
 } from '@fishjam-cloud/fishjam-proto';
-import { AgentCallbacks, Brand, FishjamConfig, PeerId } from './types';
-import { getFishjamUrl, httpToWebsocket, WithPeerId } from './utils';
+import { AgentCallbacks, Brand, FishjamConfig, Override, PeerId } from './types';
+import { getFishjamUrl, httpToWebsocket } from './utils';
 
 const expectedEventsList = ['trackData'] as const;
 /**
@@ -21,11 +21,11 @@ const expectedEventsList = ['trackData'] as const;
  */
 export type ExpectedAgentEvents = (typeof expectedEventsList)[number];
 
-export type IncomingTrackData = Omit<NonNullable<AgentResponse_TrackData>, 'peerId'> & { peerId: PeerId };
+export type IncomingTrackData = Override<NonNullable<AgentResponse_TrackData>, { peerId: PeerId }>;
 export type IncomingTrackImage = NonNullable<AgentResponse_TrackImage>;
-export type OutgoingTrackData = Omit<NonNullable<AgentRequest_TrackData>, 'peerId'> & { peerId: PeerId };
+export type OutgoingTrackData = Override<NonNullable<AgentRequest_TrackData>, { peerId: PeerId }>;
 
-export type AgentTrack = Omit<ProtoTrack, 'id'> & { id: TrackId };
+export type AgentTrack = Override<ProtoTrack, { id: TrackId }>;
 
 export type AudioCodecParameters = {
   encoding: 'opus' | 'pcm16';
@@ -40,11 +40,9 @@ type PendingImageCapture = {
   timer: ReturnType<typeof setTimeout>;
 };
 
-/**
- * @inline
- */
-type ResponseWithPeerId = WithPeerId<AgentResponse>;
-export type AgentEvents = { [K in ExpectedAgentEvents]: (message: NonNullable<ResponseWithPeerId[K]>) => void };
+export type AgentEvents = {
+  [K in ExpectedAgentEvents]: (message: Override<NonNullable<AgentResponse[K]>, { peerId: PeerId }>) => void;
+};
 
 export class FishjamAgent extends (EventEmitter as new () => TypedEmitter<AgentEvents>) {
   private readonly client: WebSocket;

--- a/packages/js-server-sdk/src/notifications.ts
+++ b/packages/js-server-sdk/src/notifications.ts
@@ -4,8 +4,7 @@ import {
   TrackType as ProtoTrackType,
   Track as ProtoTrack,
 } from '@fishjam-cloud/fishjam-proto';
-import { PeerType, TrackType } from './types';
-import { WithPeerId, WithRoomId } from './utils';
+import { Override, PeerId, PeerType, RoomId, TrackType } from './types';
 
 /**
  * Track payload embedded in {@link TrackAdded}, {@link TrackRemoved}, {@link TrackMetadataUpdated}.
@@ -83,38 +82,44 @@ export const ignoredEventsList = [
 export type IgnoredEvents = (typeof ignoredEventsList)[number];
 
 /**
+ * Field-level overrides applied to every notification payload: branded ID types
+ * and the user-facing enums replace their raw protobuf counterparts. {@link Override}
+ * only swaps keys that exist on the source type, so a single map covers all variants.
+ *
  * @inline
  */
-type MessageWithIds = WithPeerId<WithRoomId<ServerMessage>>;
+type NotificationOverrides = {
+  roomId: RoomId;
+  peerId: PeerId;
+  peerType: PeerType;
+  track: Track | undefined;
+};
 
 /** @inline */
-type WithMappedPeerType<T> = Omit<T, 'peerType'> & { peerType: PeerType };
-
-/** @inline */
-type WithMappedTrack<T> = Omit<T, 'track'> & { track: Track | undefined };
+type Notification<K extends keyof ServerMessage> = Override<NonNullable<ServerMessage[K]>, NotificationOverrides>;
 
 /**
  * @inline
  */
 export type Notifications = {
-  roomCreated: NonNullable<MessageWithIds['roomCreated']>;
-  roomDeleted: NonNullable<MessageWithIds['roomDeleted']>;
-  roomCrashed: NonNullable<MessageWithIds['roomCrashed']>;
-  peerAdded: WithMappedPeerType<NonNullable<MessageWithIds['peerAdded']>>;
-  peerDeleted: WithMappedPeerType<NonNullable<MessageWithIds['peerDeleted']>>;
-  peerConnected: WithMappedPeerType<NonNullable<MessageWithIds['peerConnected']>>;
-  peerDisconnected: WithMappedPeerType<NonNullable<MessageWithIds['peerDisconnected']>>;
-  peerMetadataUpdated: WithMappedPeerType<NonNullable<MessageWithIds['peerMetadataUpdated']>>;
-  peerCrashed: WithMappedPeerType<NonNullable<MessageWithIds['peerCrashed']>>;
-  streamerConnected: NonNullable<MessageWithIds['streamerConnected']>;
-  streamerDisconnected: NonNullable<MessageWithIds['streamerDisconnected']>;
-  viewerConnected: NonNullable<MessageWithIds['viewerConnected']>;
-  viewerDisconnected: NonNullable<MessageWithIds['viewerDisconnected']>;
-  trackAdded: WithMappedTrack<NonNullable<MessageWithIds['trackAdded']>>;
-  trackRemoved: WithMappedTrack<NonNullable<MessageWithIds['trackRemoved']>>;
-  trackMetadataUpdated: WithMappedTrack<NonNullable<MessageWithIds['trackMetadataUpdated']>>;
-  channelAdded: NonNullable<MessageWithIds['channelAdded']>;
-  channelRemoved: NonNullable<MessageWithIds['channelRemoved']>;
+  roomCreated: Notification<'roomCreated'>;
+  roomDeleted: Notification<'roomDeleted'>;
+  roomCrashed: Notification<'roomCrashed'>;
+  peerAdded: Notification<'peerAdded'>;
+  peerDeleted: Notification<'peerDeleted'>;
+  peerConnected: Notification<'peerConnected'>;
+  peerDisconnected: Notification<'peerDisconnected'>;
+  peerMetadataUpdated: Notification<'peerMetadataUpdated'>;
+  peerCrashed: Notification<'peerCrashed'>;
+  streamerConnected: Notification<'streamerConnected'>;
+  streamerDisconnected: Notification<'streamerDisconnected'>;
+  viewerConnected: Notification<'viewerConnected'>;
+  viewerDisconnected: Notification<'viewerDisconnected'>;
+  trackAdded: Notification<'trackAdded'>;
+  trackRemoved: Notification<'trackRemoved'>;
+  trackMetadataUpdated: Notification<'trackMetadataUpdated'>;
+  channelAdded: Notification<'channelAdded'>;
+  channelRemoved: Notification<'channelRemoved'>;
 };
 
 export type RoomCreated = Notifications['roomCreated'];

--- a/packages/js-server-sdk/src/types.ts
+++ b/packages/js-server-sdk/src/types.ts
@@ -19,8 +19,14 @@ export type Brand<T, TBrand extends string> = T & { [brand]: TBrand };
  *
  * Keys present in `M` but not in `T` are ignored — only fields that already exist on `T`
  * are overridden, so a shared override map can be reused across multiple source types.
+ *
+ * `undefined` is re-added to the override when the original field allowed it, so optional
+ * fields on generated proto types (e.g. `peerId?: string | undefined`) remain assignable
+ * from `undefined` under `exactOptionalPropertyTypes`.
  */
-export type Override<T, M> = { [K in keyof T]: K extends keyof M ? M[K] : T[K] };
+export type Override<T, M> = {
+  [K in keyof T]: K extends keyof M ? (undefined extends T[K] ? M[K] | undefined : M[K]) : T[K];
+};
 
 /**
  * ID of the Room.

--- a/packages/js-server-sdk/src/types.ts
+++ b/packages/js-server-sdk/src/types.ts
@@ -13,6 +13,16 @@ declare const brand: unique symbol;
 export type Brand<T, TBrand extends string> = T & { [brand]: TBrand };
 
 /**
+ * Replaces the types of fields in `T` whose names appear in `M`, leaving the rest untouched.
+ * Produces a flat object type (single mapped type, no `Omit & {...}` chain) so editor hover
+ * displays the resulting properties directly.
+ *
+ * Keys present in `M` but not in `T` are ignored — only fields that already exist on `T`
+ * are overridden, so a shared override map can be reused across multiple source types.
+ */
+export type Override<T, M> = { [K in keyof T]: K extends keyof M ? M[K] : T[K] };
+
+/**
  * ID of the Room.
  * Room can be created with {@link FishjamClient.createRoom}.
  */
@@ -22,7 +32,7 @@ export type RoomId = Brand<string, 'RoomId'>;
  */
 export type PeerId = Brand<string, 'PeerId'>;
 
-export type Peer = Omit<OpenApiPeer, 'id'> & { id: PeerId };
+export type Peer = Override<OpenApiPeer, { id: PeerId }>;
 
 /**
  * Peer type as emitted by {@link FishjamWSNotifier}. Matches the REST API's `PeerType`,

--- a/packages/js-server-sdk/src/utils.ts
+++ b/packages/js-server-sdk/src/utils.ts
@@ -18,4 +18,3 @@ export const getFishjamUrl = (config: FishjamConfig) => {
     return `https://fishjam.io/api/v1/connect/${config.fishjamId}`;
   }
 };
-

--- a/packages/js-server-sdk/src/utils.ts
+++ b/packages/js-server-sdk/src/utils.ts
@@ -1,5 +1,5 @@
 import { MissingFishjamIdException } from './exceptions';
-import type { FishjamConfig, PeerId, RoomId } from './types';
+import type { FishjamConfig } from './types';
 
 export const httpToWebsocket = (httpUrl: string) => {
   const url = new URL(httpUrl);
@@ -19,14 +19,3 @@ export const getFishjamUrl = (config: FishjamConfig) => {
   }
 };
 
-export type WithRoomId<T> = {
-  [P in keyof T]: NonNullable<T[P]> extends { roomId: string }
-    ? Omit<NonNullable<T[P]>, 'roomId'> & { roomId: RoomId }
-    : T[P];
-};
-
-export type WithPeerId<T> = {
-  [P in keyof T]: NonNullable<T[P]> extends { peerId: string }
-    ? Omit<NonNullable<T[P]>, 'peerId'> & { peerId: PeerId }
-    : T[P];
-};


### PR DESCRIPTION
## Description

Introduces override type instead of omit chaining.

## Motivation and Context

Type definitions now display properties list instead of an omit operation chain.
```
(alias) type PeerDisconnected = {
    roomId: RoomId;
    peerId: PeerId;
    peerType: PeerType;
}
import PeerDisconnected
```
vs
```
(alias) type PeerDisconnected = Omit<Omit<Omit<ServerMessage_PeerDisconnected, "roomId"> & {
    roomId: RoomId;
}, "peerId"> & {
    peerId: PeerId;
}, "peerType"> & {
    peerType: PeerType;
}
import PeerDisconnected
```

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
