### PR TITLE
FCE-2044 validate credentials at client creation

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -39,17 +39,6 @@ jobs:
       - name: Check typing
         run: yarn typecheck
 
-      - name: Generate OpenAPI reference 📸
-        run: FISHJAM_ID="openapi" FISHJAM_MANAGEMENT_TOKEN="foo" yarn gen:openapi ref.yaml
-
-      - name: Compare OpenAPI reference 🔦
-        run: |
-          RM_PATH=examples/room-manager
-          if ! cmp --silent "$RM_PATH/openapi.yaml" "$RM_PATH/ref.yaml"; then
-            echo "OpenAPI spec is out of date. Please run 'yarn gen:openapi' and commit the changes."
-            exit 1
-          fi
-
       - name: Check TypeDoc generation
         run: yarn docs
 

--- a/examples/multimodal/src/index.ts
+++ b/examples/multimodal/src/index.ts
@@ -12,7 +12,7 @@ const fishjamConfig = {
   managementToken: process.env.FISHJAM_TOKEN,
 };
 
-const fishjam = new FishjamService(fishjamConfig);
+const fishjam = await FishjamService.create(fishjamConfig);
 
 new MultimodalService(fishjamConfig, process.env.GEMINI_API_KEY);
 

--- a/examples/multimodal/src/service/fishjam.ts
+++ b/examples/multimodal/src/service/fishjam.ts
@@ -4,8 +4,13 @@ export class FishjamService {
   roomId?: RoomId;
   fishjam: FishjamClient;
 
-  constructor(config: FishjamConfig) {
-    this.fishjam = new FishjamClient(config);
+  private constructor(fishjam: FishjamClient) {
+    this.fishjam = fishjam;
+  }
+
+  static async create(config: FishjamConfig): Promise<FishjamService> {
+    const fishjam = await FishjamClient.create(config);
+    return new FishjamService(fishjam);
   }
 
   async createPeer() {

--- a/examples/room-manager/src/plugins/fishjam.ts
+++ b/examples/room-manager/src/plugins/fishjam.ts
@@ -34,7 +34,7 @@ export const fishjamPlugin = fastifyPlugin(async (fastify: FastifyInstance): Pro
     throw new Error('The `fishjamPlugin` plugin has already been registered.');
   }
 
-  const fishjamClient = new FishjamClient({
+  const fishjamClient = await FishjamClient.create({
     fishjamId: fastify.config.FISHJAM_ID,
     managementToken: fastify.config.FISHJAM_MANAGEMENT_TOKEN,
   });

--- a/examples/selective-subscription/backend/src/index.ts
+++ b/examples/selective-subscription/backend/src/index.ts
@@ -4,7 +4,7 @@ import { peerController } from './controllers/peers';
 import { notificationsController } from './controllers/notifications';
 import { FishjamService } from './service/fishjam';
 
-const fishjam = new FishjamService({
+const fishjam = await FishjamService.create({
   fishjamId: process.env.FISHJAM_ID!,
   managementToken: process.env.FISHJAM_TOKEN!,
 });

--- a/examples/selective-subscription/backend/src/service/fishjam.ts
+++ b/examples/selective-subscription/backend/src/service/fishjam.ts
@@ -12,9 +12,9 @@ export class FishjamService extends EventTarget {
   roomId?: RoomId;
   fishjam: FishjamClient;
 
-  constructor(config: FishjamConfig) {
+  private constructor(fishjam: FishjamClient, config: FishjamConfig) {
     super();
-    this.fishjam = new FishjamClient(config);
+    this.fishjam = fishjam;
     const notifier = new FishjamWSNotifier(
       config,
       () => {},
@@ -25,6 +25,11 @@ export class FishjamService extends EventTarget {
     notifier.on('peerDisconnected', (msg) => this.emit('peerDisconnected', msg));
     notifier.on('trackAdded', (msg) => this.emit('trackAdded', msg));
     notifier.on('trackRemoved', (msg) => this.emit('trackRemoved', msg));
+  }
+
+  static async create(config: FishjamConfig): Promise<FishjamService> {
+    const fishjam = await FishjamClient.create(config);
+    return new FishjamService(fishjam, config);
   }
 
   async createPeer() {

--- a/examples/transcription/src/index.ts
+++ b/examples/transcription/src/index.ts
@@ -12,7 +12,7 @@ const fishjamConfig = {
   managementToken: process.env.FISHJAM_TOKEN,
 };
 
-const fishjam = new FishjamService(fishjamConfig);
+const fishjam = await FishjamService.create(fishjamConfig);
 
 new TranscriptionService(fishjamConfig, process.env.GEMINI_API_KEY);
 

--- a/examples/transcription/src/service/fishjam.ts
+++ b/examples/transcription/src/service/fishjam.ts
@@ -4,8 +4,13 @@ export class FishjamService {
   roomId?: RoomId;
   fishjam: FishjamClient;
 
-  constructor(config: FishjamConfig) {
-    this.fishjam = new FishjamClient(config);
+  private constructor(fishjam: FishjamClient) {
+    this.fishjam = fishjam;
+  }
+
+  static async create(config: FishjamConfig): Promise<FishjamService> {
+    const fishjam = await FishjamClient.create(config);
+    return new FishjamService(fishjam);
   }
 
   async createPeer() {

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -32,9 +32,11 @@ export class FishjamClient {
   /**
    * Create new instance of Fishjam Client.
    *
-   * The constructor does NOT verify the provided credentials against the
-   * Fishjam backend. Use {@link FishjamClient.create} or
-   * {@link FishjamClient.checkCredentials} to verify them at construction time.
+   * Throws {@link MissingFishjamIdException} or
+   * {@link MissingManagementTokenException} if either field is missing.
+   * Does not verify credentials against the backend — use
+   * {@link FishjamClient.create} or call
+   * {@link FishjamClient.checkCredentials} afterwards for that.
    *
    * Example usage:
    * ```
@@ -68,11 +70,12 @@ export class FishjamClient {
   }
 
   /**
-   * Async factory. Constructs a client and verifies that the provided
-   * `fishjamId` and `managementToken` are accepted by the Fishjam backend.
+   * Async factory: constructs a client and verifies credentials against
+   * the backend.
    *
-   * Throws {@link InvalidFishjamConfigException} for malformed config,
-   * {@link UnauthorizedException} for bad credentials, or
+   * Throws {@link MissingFishjamIdException} /
+   * {@link MissingManagementTokenException} for missing fields,
+   * {@link UnauthorizedException} for bad credentials,
    * {@link FishjamNotFoundException} for an unknown `fishjamId`.
    *
    * Example:

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -12,7 +12,7 @@ import {
 } from '@fishjam-cloud/fishjam-openapi';
 import type { AgentCallbacks, FishjamConfig, PeerId, Room, RoomId, Peer } from './types';
 import { mapException } from './exceptions/mapper';
-import { getFishjamUrl } from './utils';
+import { getFishjamUrl, validateFishjamConfig } from './utils';
 import { FishjamAgent, TrackId } from './agent';
 import packageJson from '../package.json';
 
@@ -32,6 +32,10 @@ export class FishjamClient {
   /**
    * Create new instance of Fishjam Client.
    *
+   * The constructor does NOT verify the provided credentials against the
+   * Fishjam backend. Use {@link FishjamClient.create} or
+   * {@link FishjamClient.checkCredentials} to verify them at construction time.
+   *
    * Example usage:
    * ```
    * const fishjamClient = new FishjamClient({
@@ -41,6 +45,7 @@ export class FishjamClient {
    * ```
    */
   constructor(config: FishjamConfig) {
+    validateFishjamConfig(config);
     const client = axios.create({
       headers: {
         Authorization: `Bearer ${config.managementToken}`,
@@ -60,6 +65,42 @@ export class FishjamClient {
     this.viewerApi = new ViewersApi(undefined, fishjamUrl, client);
     this.streamerApi = new StreamersApi(undefined, fishjamUrl, client);
     this.fishjamConfig = config;
+  }
+
+  /**
+   * Async factory. Constructs a client and verifies that the provided
+   * `fishjamId` and `managementToken` are accepted by the Fishjam backend.
+   *
+   * Throws {@link InvalidFishjamConfigException} for malformed config,
+   * {@link UnauthorizedException} for bad credentials, or
+   * {@link FishjamNotFoundException} for an unknown `fishjamId`.
+   *
+   * Example:
+   * ```
+   * const client = await FishjamClient.create({
+   *   fishjamId: process.env.FISHJAM_ID!,
+   *   managementToken: process.env.FISHJAM_MANAGEMENT_TOKEN!,
+   * });
+   * ```
+   */
+  static async create(config: FishjamConfig): Promise<FishjamClient> {
+    const client = new FishjamClient(config);
+    await client.checkCredentials();
+    return client;
+  }
+
+  /**
+   * Verifies the configured credentials by making a single lightweight
+   * call to the Fishjam backend. Resolves on success, otherwise throws the
+   * same exception types thrown by other client methods (notably
+   * {@link UnauthorizedException} and {@link FishjamNotFoundException}).
+   */
+  async checkCredentials(): Promise<void> {
+    try {
+      await this.roomApi.getAllRooms();
+    } catch (error) {
+      throw mapException(error);
+    }
   }
 
   private handleDeprecationHeader(headers: RawAxiosResponseHeaders): void {

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -12,7 +12,8 @@ import {
 } from '@fishjam-cloud/fishjam-openapi';
 import type { AgentCallbacks, FishjamConfig, PeerId, Room, RoomId, Peer } from './types';
 import { mapException } from './exceptions/mapper';
-import { getFishjamUrl, validateFishjamConfig } from './utils';
+import { InvalidFishjamCredentialsException } from './exceptions';
+import { getFishjamUrl } from './utils';
 import { FishjamAgent, TrackId } from './agent';
 import packageJson from '../package.json';
 
@@ -32,8 +33,6 @@ export class FishjamClient {
   /**
    * Create new instance of Fishjam Client.
    *
-   * Throws {@link MissingFishjamIdException} or
-   * {@link MissingManagementTokenException} if either field is missing.
    * Does not verify credentials against the backend — use
    * {@link FishjamClient.create} or call
    * {@link FishjamClient.checkCredentials} afterwards for that.
@@ -47,7 +46,6 @@ export class FishjamClient {
    * ```
    */
   constructor(config: FishjamConfig) {
-    validateFishjamConfig(config);
     const client = axios.create({
       headers: {
         Authorization: `Bearer ${config.managementToken}`,
@@ -73,10 +71,8 @@ export class FishjamClient {
    * Async factory: constructs a client and verifies credentials against
    * the backend.
    *
-   * Throws {@link MissingFishjamIdException} /
-   * {@link MissingManagementTokenException} for missing fields,
-   * {@link UnauthorizedException} for bad credentials,
-   * {@link FishjamNotFoundException} for an unknown `fishjamId`.
+   * Throws {@link InvalidFishjamCredentialsException} when the
+   * `fishjamId` / `managementToken` pair is rejected by the backend.
    *
    * Example:
    * ```
@@ -94,14 +90,20 @@ export class FishjamClient {
 
   /**
    * Verifies the configured credentials by making a single lightweight
-   * call to the Fishjam backend. Resolves on success, otherwise throws the
-   * same exception types thrown by other client methods (notably
-   * {@link UnauthorizedException} and {@link FishjamNotFoundException}).
+   * call to the Fishjam backend. Resolves on success, throws
+   * {@link InvalidFishjamCredentialsException} on 401/404 from the backend,
+   * otherwise rethrows the standard mapped exception.
    */
   async checkCredentials(): Promise<void> {
     try {
       await this.roomApi.getAllRooms();
     } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        if (status === 401 || status === 404) {
+          throw new InvalidFishjamCredentialsException(error);
+        }
+      }
       throw mapException(error);
     }
   }

--- a/packages/js-server-sdk/src/exceptions/index.ts
+++ b/packages/js-server-sdk/src/exceptions/index.ts
@@ -6,6 +6,12 @@ export class MissingFishjamIdException extends Error {
   }
 }
 
+export class MissingManagementTokenException extends Error {
+  constructor() {
+    super('Management Token is required');
+  }
+}
+
 export class FishjamBaseException extends Error {
   statusCode: number;
   axiosCode?: string;

--- a/packages/js-server-sdk/src/exceptions/index.ts
+++ b/packages/js-server-sdk/src/exceptions/index.ts
@@ -6,12 +6,6 @@ export class MissingFishjamIdException extends Error {
   }
 }
 
-export class MissingManagementTokenException extends Error {
-  constructor() {
-    super('Management Token is required');
-  }
-}
-
 export class FishjamBaseException extends Error {
   statusCode: number;
   axiosCode?: string;
@@ -33,6 +27,8 @@ export class ForbiddenException extends FishjamBaseException {}
 export class RoomNotFoundException extends FishjamBaseException {}
 
 export class FishjamNotFoundException extends FishjamBaseException {}
+
+export class InvalidFishjamCredentialsException extends FishjamBaseException {}
 
 export class PeerNotFoundException extends FishjamBaseException {}
 

--- a/packages/js-server-sdk/src/utils.ts
+++ b/packages/js-server-sdk/src/utils.ts
@@ -1,4 +1,4 @@
-import { MissingFishjamIdException } from './exceptions';
+import { MissingFishjamIdException, MissingManagementTokenException } from './exceptions';
 import type { FishjamConfig } from './types';
 
 export const httpToWebsocket = (httpUrl: string) => {
@@ -7,6 +7,11 @@ export const httpToWebsocket = (httpUrl: string) => {
   // note that this will handle http as well as https
   url.protocol = url.protocol.replace('http', 'ws');
   return url.href;
+};
+
+export const validateFishjamConfig = (config: FishjamConfig): void => {
+  if (!config?.fishjamId) throw new MissingFishjamIdException();
+  if (!config?.managementToken) throw new MissingManagementTokenException();
 };
 
 export const getFishjamUrl = (config: FishjamConfig) => {

--- a/packages/js-server-sdk/src/utils.ts
+++ b/packages/js-server-sdk/src/utils.ts
@@ -1,4 +1,4 @@
-import { MissingFishjamIdException, MissingManagementTokenException } from './exceptions';
+import { MissingFishjamIdException } from './exceptions';
 import type { FishjamConfig } from './types';
 
 export const httpToWebsocket = (httpUrl: string) => {
@@ -7,11 +7,6 @@ export const httpToWebsocket = (httpUrl: string) => {
   // note that this will handle http as well as https
   url.protocol = url.protocol.replace('http', 'ws');
   return url.href;
-};
-
-export const validateFishjamConfig = (config: FishjamConfig): void => {
-  if (!config?.fishjamId) throw new MissingFishjamIdException();
-  if (!config?.managementToken) throw new MissingManagementTokenException();
 };
 
 export const getFishjamUrl = (config: FishjamConfig) => {

--- a/packages/js-server-sdk/tests/config-validation.test.ts
+++ b/packages/js-server-sdk/tests/config-validation.test.ts
@@ -28,10 +28,11 @@ describe('FishjamClient constructor sync validation', () => {
 });
 
 describe('FishjamClient live credential checks (mocked)', () => {
-  let getAllRoomsSpy: ReturnType<typeof vi.spyOn>;
+  const spy = () => vi.spyOn(RoomsApi.prototype, 'getAllRooms');
+  let getAllRoomsSpy: ReturnType<typeof spy>;
 
   beforeEach(() => {
-    getAllRoomsSpy = vi.spyOn(RoomsApi.prototype, 'getAllRooms');
+    getAllRoomsSpy = spy();
   });
 
   afterEach(() => {

--- a/packages/js-server-sdk/tests/config-validation.test.ts
+++ b/packages/js-server-sdk/tests/config-validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { RoomsApi } from '@fishjam-cloud/fishjam-openapi';
 import { FishjamClient } from '../src/client';
-import { MissingFishjamIdException, MissingManagementTokenException, UnauthorizedException } from '../src/exceptions';
+import { InvalidFishjamCredentialsException, MissingFishjamIdException } from '../src/exceptions';
 import type { FishjamConfig } from '../src/types';
 
 const VALID_CONFIG: FishjamConfig = { fishjamId: 'fjm_test', managementToken: 'tok_test' };
@@ -16,10 +16,6 @@ const axiosError = (status: number, detail = 'error') => ({
 describe('FishjamClient constructor sync validation', () => {
   it('throws MissingFishjamIdException when fishjamId is empty', () => {
     expect(() => new FishjamClient({ fishjamId: '', managementToken: 'tok' })).toThrow(MissingFishjamIdException);
-  });
-
-  it('throws MissingManagementTokenException when managementToken is empty', () => {
-    expect(() => new FishjamClient({ fishjamId: 'fjm', managementToken: '' })).toThrow(MissingManagementTokenException);
   });
 
   it('does not throw when both fields are provided', () => {
@@ -39,10 +35,16 @@ describe('FishjamClient live credential checks (mocked)', () => {
     getAllRoomsSpy.mockRestore();
   });
 
-  it('FishjamClient.create rejects with UnauthorizedException on 401', async () => {
+  it('FishjamClient.create rejects with InvalidFishjamCredentialsException on 401', async () => {
     getAllRoomsSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
 
-    await expect(FishjamClient.create(VALID_CONFIG)).rejects.toThrow(UnauthorizedException);
+    await expect(FishjamClient.create(VALID_CONFIG)).rejects.toThrow(InvalidFishjamCredentialsException);
+  });
+
+  it('FishjamClient.create rejects with InvalidFishjamCredentialsException on 404', async () => {
+    getAllRoomsSpy.mockRejectedValueOnce(axiosError(404, 'Fishjam not found'));
+
+    await expect(FishjamClient.create(VALID_CONFIG)).rejects.toThrow(InvalidFishjamCredentialsException);
   });
 
   it('FishjamClient.create resolves and pings backend once on success', async () => {
@@ -54,11 +56,18 @@ describe('FishjamClient live credential checks (mocked)', () => {
     expect(getAllRoomsSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('checkCredentials throws UnauthorizedException on 401', async () => {
+  it('checkCredentials throws InvalidFishjamCredentialsException on 401', async () => {
     getAllRoomsSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
 
     const client = new FishjamClient(VALID_CONFIG);
-    await expect(client.checkCredentials()).rejects.toThrow(UnauthorizedException);
+    await expect(client.checkCredentials()).rejects.toThrow(InvalidFishjamCredentialsException);
+  });
+
+  it('checkCredentials throws InvalidFishjamCredentialsException on 404', async () => {
+    getAllRoomsSpy.mockRejectedValueOnce(axiosError(404, 'Fishjam not found'));
+
+    const client = new FishjamClient(VALID_CONFIG);
+    await expect(client.checkCredentials()).rejects.toThrow(InvalidFishjamCredentialsException);
   });
 
   it('checkCredentials resolves on success', async () => {

--- a/packages/js-server-sdk/tests/config-validation.test.ts
+++ b/packages/js-server-sdk/tests/config-validation.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { RoomsApi } from '@fishjam-cloud/fishjam-openapi';
 import { FishjamClient } from '../src/client';
-import {
-  MissingFishjamIdException,
-  MissingManagementTokenException,
-  UnauthorizedException,
-} from '../src/exceptions';
+import { MissingFishjamIdException, MissingManagementTokenException, UnauthorizedException } from '../src/exceptions';
 import type { FishjamConfig } from '../src/types';
 
 const VALID_CONFIG: FishjamConfig = { fishjamId: 'fjm_test', managementToken: 'tok_test' };
@@ -19,15 +15,11 @@ const axiosError = (status: number, detail = 'error') => ({
 
 describe('FishjamClient constructor sync validation', () => {
   it('throws MissingFishjamIdException when fishjamId is empty', () => {
-    expect(() => new FishjamClient({ fishjamId: '', managementToken: 'tok' })).toThrow(
-      MissingFishjamIdException
-    );
+    expect(() => new FishjamClient({ fishjamId: '', managementToken: 'tok' })).toThrow(MissingFishjamIdException);
   });
 
   it('throws MissingManagementTokenException when managementToken is empty', () => {
-    expect(() => new FishjamClient({ fishjamId: 'fjm', managementToken: '' })).toThrow(
-      MissingManagementTokenException
-    );
+    expect(() => new FishjamClient({ fishjamId: 'fjm', managementToken: '' })).toThrow(MissingManagementTokenException);
   });
 
   it('does not throw when both fields are provided', () => {

--- a/packages/js-server-sdk/tests/config-validation.test.ts
+++ b/packages/js-server-sdk/tests/config-validation.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RoomsApi } from '@fishjam-cloud/fishjam-openapi';
+import { FishjamClient } from '../src/client';
+import {
+  MissingFishjamIdException,
+  MissingManagementTokenException,
+  UnauthorizedException,
+} from '../src/exceptions';
+import type { FishjamConfig } from '../src/types';
+
+const VALID_CONFIG: FishjamConfig = { fishjamId: 'fjm_test', managementToken: 'tok_test' };
+
+const axiosError = (status: number, detail = 'error') => ({
+  isAxiosError: true,
+  message: `Request failed with status code ${status}`,
+  code: 'ERR_BAD_REQUEST',
+  response: { status, data: { detail } },
+});
+
+describe('FishjamClient constructor sync validation', () => {
+  it('throws MissingFishjamIdException when fishjamId is empty', () => {
+    expect(() => new FishjamClient({ fishjamId: '', managementToken: 'tok' })).toThrow(
+      MissingFishjamIdException
+    );
+  });
+
+  it('throws MissingManagementTokenException when managementToken is empty', () => {
+    expect(() => new FishjamClient({ fishjamId: 'fjm', managementToken: '' })).toThrow(
+      MissingManagementTokenException
+    );
+  });
+
+  it('does not throw when both fields are provided', () => {
+    expect(() => new FishjamClient(VALID_CONFIG)).not.toThrow();
+  });
+});
+
+describe('FishjamClient live credential checks (mocked)', () => {
+  let getAllRoomsSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    getAllRoomsSpy = vi.spyOn(RoomsApi.prototype, 'getAllRooms');
+  });
+
+  afterEach(() => {
+    getAllRoomsSpy.mockRestore();
+  });
+
+  it('FishjamClient.create rejects with UnauthorizedException on 401', async () => {
+    getAllRoomsSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
+
+    await expect(FishjamClient.create(VALID_CONFIG)).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('FishjamClient.create resolves and pings backend once on success', async () => {
+    getAllRoomsSpy.mockResolvedValueOnce({ data: { data: [] } } as never);
+
+    const client = await FishjamClient.create(VALID_CONFIG);
+
+    expect(client).toBeInstanceOf(FishjamClient);
+    expect(getAllRoomsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('checkCredentials throws UnauthorizedException on 401', async () => {
+    getAllRoomsSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
+
+    const client = new FishjamClient(VALID_CONFIG);
+    await expect(client.checkCredentials()).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('checkCredentials resolves on success', async () => {
+    getAllRoomsSpy.mockResolvedValueOnce({ data: { data: [] } } as never);
+
+    const client = new FishjamClient(VALID_CONFIG);
+    await expect(client.checkCredentials()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description

Adds credentials validation to the preferred way of creating the client.
There is also a separate checkCredentials method if someone needs to create the client synchronously.

## Motivation and Context

The SDK client should fail fast when misconfigured.

## Documentation impact

- [ ] Documentation update required
- [x] Documentation updated [in another PR](https://github.com/fishjam-cloud/documentation/pull/259)
- [ ] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
