### PR TITLE
FCE-2044 use validate api for credentials check

### DIFF
--- a/packages/fishjam-openapi/src/generated/api.ts
+++ b/packages/fishjam-openapi/src/generated/api.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Fishjam API
- * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup) 
+ * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup)
  *
  * The version of the OpenAPI document: 0.27.0
  * Contact: contact@fishjam.io
@@ -12,13 +12,23 @@
  * Do not edit the class manually.
  */
 
-
 import type { Configuration } from './configuration';
 import type { AxiosPromise, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
 // Some imports not used depending on template conditions
 // @ts-ignore
-import { DUMMY_BASE_URL, assertParamExists, setApiKeyToObject, setBasicAuthToObject, setBearerAuthToObject, setOAuthToObject, setSearchParams, serializeDataIfNeeded, toPathString, createRequestFunction } from './common';
+import {
+  DUMMY_BASE_URL,
+  assertParamExists,
+  setApiKeyToObject,
+  setBasicAuthToObject,
+  setBearerAuthToObject,
+  setOAuthToObject,
+  setSearchParams,
+  serializeDataIfNeeded,
+  toPathString,
+  createRequestFunction,
+} from './common';
 import type { RequestArgs } from './base';
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerMap } from './base';
@@ -29,20 +39,19 @@ import { BASE_PATH, COLLECTION_FORMATS, BaseAPI, RequiredError, operationServerM
  * @interface AgentOutput
  */
 export interface AgentOutput {
-    /**
-     * 
-     * @type {AudioFormat}
-     * @memberof AgentOutput
-     */
-    'audioFormat'?: AudioFormat;
-    /**
-     * 
-     * @type {AudioSampleRate}
-     * @memberof AgentOutput
-     */
-    'audioSampleRate'?: AudioSampleRate;
+  /**
+   *
+   * @type {AudioFormat}
+   * @memberof AgentOutput
+   */
+  audioFormat?: AudioFormat;
+  /**
+   *
+   * @type {AudioSampleRate}
+   * @memberof AgentOutput
+   */
+  audioSampleRate?: AudioSampleRate;
 }
-
 
 /**
  * The format of the output audio
@@ -51,11 +60,10 @@ export interface AgentOutput {
  */
 
 export const AudioFormat = {
-    Pcm16: 'pcm16'
+  Pcm16: 'pcm16',
 } as const;
 
-export type AudioFormat = typeof AudioFormat[keyof typeof AudioFormat];
-
+export type AudioFormat = (typeof AudioFormat)[keyof typeof AudioFormat];
 
 /**
  * The sample rate of the output audio
@@ -64,12 +72,11 @@ export type AudioFormat = typeof AudioFormat[keyof typeof AudioFormat];
  */
 
 export const AudioSampleRate = {
-    NUMBER_16000: 16000,
-    NUMBER_24000: 24000
+  NUMBER_16000: 16000,
+  NUMBER_24000: 24000,
 } as const;
 
-export type AudioSampleRate = typeof AudioSampleRate[keyof typeof AudioSampleRate];
-
+export type AudioSampleRate = (typeof AudioSampleRate)[keyof typeof AudioSampleRate];
 
 /**
  * Composition and track forwarding state for the room
@@ -77,18 +84,18 @@ export type AudioSampleRate = typeof AudioSampleRate[keyof typeof AudioSampleRat
  * @interface CompositionInfo
  */
 export interface CompositionInfo {
-    /**
-     * URL of the active composition
-     * @type {string}
-     * @memberof CompositionInfo
-     */
-    'compositionUrl': string;
-    /**
-     * List of active track forwardings
-     * @type {Array<TrackForwardingInfo>}
-     * @memberof CompositionInfo
-     */
-    'forwardings': Array<TrackForwardingInfo>;
+  /**
+   * URL of the active composition
+   * @type {string}
+   * @memberof CompositionInfo
+   */
+  compositionUrl: string;
+  /**
+   * List of active track forwardings
+   * @type {Array<TrackForwardingInfo>}
+   * @memberof CompositionInfo
+   */
+  forwardings: Array<TrackForwardingInfo>;
 }
 /**
  * Error message
@@ -96,12 +103,12 @@ export interface CompositionInfo {
  * @interface ModelError
  */
 export interface ModelError {
-    /**
-     * Error details
-     * @type {string}
-     * @memberof ModelError
-     */
-    'errors': string;
+  /**
+   * Error details
+   * @type {string}
+   * @memberof ModelError
+   */
+  errors: string;
 }
 /**
  * Token for authorizing a MoQ relay connection
@@ -109,12 +116,12 @@ export interface ModelError {
  * @interface MoqToken
  */
 export interface MoqToken {
-    /**
-     * JWT token for MoQ relay
-     * @type {string}
-     * @memberof MoqToken
-     */
-    'token': string;
+  /**
+   * JWT token for MoQ relay
+   * @type {string}
+   * @memberof MoqToken
+   */
+  token: string;
 }
 /**
  * MoQ token configuration
@@ -122,18 +129,18 @@ export interface MoqToken {
  * @interface MoqTokenConfig
  */
 export interface MoqTokenConfig {
-    /**
-     * Path under the root the token grants publish access to
-     * @type {string}
-     * @memberof MoqTokenConfig
-     */
-    'publishPath'?: string | null;
-    /**
-     * Path under the root the token grants subscribe access to
-     * @type {string}
-     * @memberof MoqTokenConfig
-     */
-    'subscribePath'?: string | null;
+  /**
+   * Path under the root the token grants publish access to
+   * @type {string}
+   * @memberof MoqTokenConfig
+   */
+  publishPath?: string | null;
+  /**
+   * Path under the root the token grants subscribe access to
+   * @type {string}
+   * @memberof MoqTokenConfig
+   */
+  subscribePath?: string | null;
 }
 /**
  * Describes peer status
@@ -141,50 +148,49 @@ export interface MoqTokenConfig {
  * @interface Peer
  */
 export interface Peer {
-    /**
-     * Assigned peer id
-     * @type {string}
-     * @memberof Peer
-     */
-    'id': string;
-    /**
-     * Custom metadata set by the peer
-     * @type {object}
-     * @memberof Peer
-     */
-    'metadata': object | null;
-    /**
-     * 
-     * @type {PeerStatus}
-     * @memberof Peer
-     */
-    'status': PeerStatus;
-    /**
-     * 
-     * @type {SubscribeMode}
-     * @memberof Peer
-     */
-    'subscribeMode': SubscribeMode;
-    /**
-     * 
-     * @type {Subscriptions}
-     * @memberof Peer
-     */
-    'subscriptions': Subscriptions;
-    /**
-     * List of all peer\'s tracks
-     * @type {Array<Track>}
-     * @memberof Peer
-     */
-    'tracks': Array<Track>;
-    /**
-     * 
-     * @type {PeerType}
-     * @memberof Peer
-     */
-    'type': PeerType;
+  /**
+   * Assigned peer id
+   * @type {string}
+   * @memberof Peer
+   */
+  id: string;
+  /**
+   * Custom metadata set by the peer
+   * @type {object}
+   * @memberof Peer
+   */
+  metadata: object | null;
+  /**
+   *
+   * @type {PeerStatus}
+   * @memberof Peer
+   */
+  status: PeerStatus;
+  /**
+   *
+   * @type {SubscribeMode}
+   * @memberof Peer
+   */
+  subscribeMode: SubscribeMode;
+  /**
+   *
+   * @type {Subscriptions}
+   * @memberof Peer
+   */
+  subscriptions: Subscriptions;
+  /**
+   * List of all peer\'s tracks
+   * @type {Array<Track>}
+   * @memberof Peer
+   */
+  tracks: Array<Track>;
+  /**
+   *
+   * @type {PeerType}
+   * @memberof Peer
+   */
+  type: PeerType;
 }
-
 
 /**
  * Peer configuration
@@ -192,20 +198,19 @@ export interface Peer {
  * @interface PeerConfig
  */
 export interface PeerConfig {
-    /**
-     * 
-     * @type {PeerOptions}
-     * @memberof PeerConfig
-     */
-    'options': PeerOptions;
-    /**
-     * 
-     * @type {PeerType}
-     * @memberof PeerConfig
-     */
-    'type': PeerType;
+  /**
+   *
+   * @type {PeerOptions}
+   * @memberof PeerConfig
+   */
+  options: PeerOptions;
+  /**
+   *
+   * @type {PeerType}
+   * @memberof PeerConfig
+   */
+  type: PeerType;
 }
-
 
 /**
  * Response containing peer details and their token
@@ -213,37 +218,37 @@ export interface PeerConfig {
  * @interface PeerDetailsResponse
  */
 export interface PeerDetailsResponse {
-    /**
-     * 
-     * @type {PeerDetailsResponseData}
-     * @memberof PeerDetailsResponse
-     */
-    'data': PeerDetailsResponseData;
+  /**
+   *
+   * @type {PeerDetailsResponseData}
+   * @memberof PeerDetailsResponse
+   */
+  data: PeerDetailsResponseData;
 }
 /**
- * 
+ *
  * @export
  * @interface PeerDetailsResponseData
  */
 export interface PeerDetailsResponseData {
-    /**
-     * 
-     * @type {Peer}
-     * @memberof PeerDetailsResponseData
-     */
-    'peer': Peer;
-    /**
-     * Websocket URL to which peer has to connect
-     * @type {string}
-     * @memberof PeerDetailsResponseData
-     */
-    'peer_websocket_url'?: string;
-    /**
-     * Token for authorizing websocket connection
-     * @type {string}
-     * @memberof PeerDetailsResponseData
-     */
-    'token': string;
+  /**
+   *
+   * @type {Peer}
+   * @memberof PeerDetailsResponseData
+   */
+  peer: Peer;
+  /**
+   * Websocket URL to which peer has to connect
+   * @type {string}
+   * @memberof PeerDetailsResponseData
+   */
+  peer_websocket_url?: string;
+  /**
+   * Token for authorizing websocket connection
+   * @type {string}
+   * @memberof PeerDetailsResponseData
+   */
+  token: string;
 }
 /**
  * @type PeerOptions
@@ -258,20 +263,19 @@ export type PeerOptions = PeerOptionsAgent | PeerOptionsVapi | PeerOptionsWebRTC
  * @interface PeerOptionsAgent
  */
 export interface PeerOptionsAgent {
-    /**
-     * 
-     * @type {AgentOutput}
-     * @memberof PeerOptionsAgent
-     */
-    'output'?: AgentOutput;
-    /**
-     * 
-     * @type {SubscribeMode}
-     * @memberof PeerOptionsAgent
-     */
-    'subscribeMode'?: SubscribeMode;
+  /**
+   *
+   * @type {AgentOutput}
+   * @memberof PeerOptionsAgent
+   */
+  output?: AgentOutput;
+  /**
+   *
+   * @type {SubscribeMode}
+   * @memberof PeerOptionsAgent
+   */
+  subscribeMode?: SubscribeMode;
 }
-
 
 /**
  * Options specific to the VAPI peer
@@ -279,26 +283,25 @@ export interface PeerOptionsAgent {
  * @interface PeerOptionsVapi
  */
 export interface PeerOptionsVapi {
-    /**
-     * VAPI API key
-     * @type {string}
-     * @memberof PeerOptionsVapi
-     */
-    'apiKey': string;
-    /**
-     * VAPI call ID
-     * @type {string}
-     * @memberof PeerOptionsVapi
-     */
-    'callId': string;
-    /**
-     * 
-     * @type {SubscribeMode}
-     * @memberof PeerOptionsVapi
-     */
-    'subscribeMode'?: SubscribeMode;
+  /**
+   * VAPI API key
+   * @type {string}
+   * @memberof PeerOptionsVapi
+   */
+  apiKey: string;
+  /**
+   * VAPI call ID
+   * @type {string}
+   * @memberof PeerOptionsVapi
+   */
+  callId: string;
+  /**
+   *
+   * @type {SubscribeMode}
+   * @memberof PeerOptionsVapi
+   */
+  subscribeMode?: SubscribeMode;
 }
-
 
 /**
  * Options specific to the WebRTC peer
@@ -306,20 +309,19 @@ export interface PeerOptionsVapi {
  * @interface PeerOptionsWebRTC
  */
 export interface PeerOptionsWebRTC {
-    /**
-     * Custom peer metadata
-     * @type {{ [key: string]: any; }}
-     * @memberof PeerOptionsWebRTC
-     */
-    'metadata'?: { [key: string]: any; };
-    /**
-     * 
-     * @type {SubscribeMode}
-     * @memberof PeerOptionsWebRTC
-     */
-    'subscribeMode'?: SubscribeMode;
+  /**
+   * Custom peer metadata
+   * @type {{ [key: string]: any; }}
+   * @memberof PeerOptionsWebRTC
+   */
+  metadata?: { [key: string]: any };
+  /**
+   *
+   * @type {SubscribeMode}
+   * @memberof PeerOptionsWebRTC
+   */
+  subscribeMode?: SubscribeMode;
 }
-
 
 /**
  * Response containing new peer token
@@ -327,25 +329,25 @@ export interface PeerOptionsWebRTC {
  * @interface PeerRefreshTokenResponse
  */
 export interface PeerRefreshTokenResponse {
-    /**
-     * 
-     * @type {PeerRefreshTokenResponseData}
-     * @memberof PeerRefreshTokenResponse
-     */
-    'data': PeerRefreshTokenResponseData;
+  /**
+   *
+   * @type {PeerRefreshTokenResponseData}
+   * @memberof PeerRefreshTokenResponse
+   */
+  data: PeerRefreshTokenResponseData;
 }
 /**
- * 
+ *
  * @export
  * @interface PeerRefreshTokenResponseData
  */
 export interface PeerRefreshTokenResponseData {
-    /**
-     * Token for authorizing websocket connection
-     * @type {string}
-     * @memberof PeerRefreshTokenResponseData
-     */
-    'token': string;
+  /**
+   * Token for authorizing websocket connection
+   * @type {string}
+   * @memberof PeerRefreshTokenResponseData
+   */
+  token: string;
 }
 /**
  * Informs about the peer status
@@ -354,12 +356,11 @@ export interface PeerRefreshTokenResponseData {
  */
 
 export const PeerStatus = {
-    Connected: 'connected',
-    Disconnected: 'disconnected'
+  Connected: 'connected',
+  Disconnected: 'disconnected',
 } as const;
 
-export type PeerStatus = typeof PeerStatus[keyof typeof PeerStatus];
-
+export type PeerStatus = (typeof PeerStatus)[keyof typeof PeerStatus];
 
 /**
  * Peer type
@@ -368,13 +369,12 @@ export type PeerStatus = typeof PeerStatus[keyof typeof PeerStatus];
  */
 
 export const PeerType = {
-    Webrtc: 'webrtc',
-    Agent: 'agent',
-    Vapi: 'vapi'
+  Webrtc: 'webrtc',
+  Agent: 'agent',
+  Vapi: 'vapi',
 } as const;
 
-export type PeerType = typeof PeerType[keyof typeof PeerType];
-
+export type PeerType = (typeof PeerType)[keyof typeof PeerType];
 
 /**
  * State of a room
@@ -382,30 +382,30 @@ export type PeerType = typeof PeerType[keyof typeof PeerType];
  * @interface Room
  */
 export interface Room {
-    /**
-     * 
-     * @type {CompositionInfo}
-     * @memberof Room
-     */
-    'compositionInfo'?: CompositionInfo | null;
-    /**
-     * 
-     * @type {RoomConfig}
-     * @memberof Room
-     */
-    'config': RoomConfig;
-    /**
-     * Room ID
-     * @type {string}
-     * @memberof Room
-     */
-    'id': string;
-    /**
-     * List of all peers
-     * @type {Array<Peer>}
-     * @memberof Room
-     */
-    'peers': Array<Peer>;
+  /**
+   *
+   * @type {CompositionInfo}
+   * @memberof Room
+   */
+  compositionInfo?: CompositionInfo | null;
+  /**
+   *
+   * @type {RoomConfig}
+   * @memberof Room
+   */
+  config: RoomConfig;
+  /**
+   * Room ID
+   * @type {string}
+   * @memberof Room
+   */
+  id: string;
+  /**
+   * List of all peers
+   * @type {Array<Peer>}
+   * @memberof Room
+   */
+  peers: Array<Peer>;
 }
 /**
  * Room configuration
@@ -413,44 +413,43 @@ export interface Room {
  * @interface RoomConfig
  */
 export interface RoomConfig {
-    /**
-     * If true, webhook notifications for this room are coalesced into a single NotificationBatch per HTTP send instead of one request per notification. VAD notifications are unaffected.
-     * @type {boolean}
-     * @memberof RoomConfig
-     */
-    'batchWebhookNotifications'?: boolean;
-    /**
-     * Maximum amount of peers allowed into the room
-     * @type {number}
-     * @memberof RoomConfig
-     */
-    'maxPeers'?: number | null;
-    /**
-     * True if livestream viewers can omit specifying a token.
-     * @type {boolean}
-     * @memberof RoomConfig
-     */
-    'public'?: boolean;
-    /**
-     * 
-     * @type {RoomType}
-     * @memberof RoomConfig
-     */
-    'roomType'?: RoomType;
-    /**
-     * 
-     * @type {VideoCodec}
-     * @memberof RoomConfig
-     */
-    'videoCodec'?: VideoCodec;
-    /**
-     * URL where Fishjam notifications will be sent
-     * @type {string}
-     * @memberof RoomConfig
-     */
-    'webhookUrl'?: string | null;
+  /**
+   * If true, webhook notifications for this room are coalesced into a single NotificationBatch per HTTP send instead of one request per notification. VAD notifications are unaffected.
+   * @type {boolean}
+   * @memberof RoomConfig
+   */
+  batchWebhookNotifications?: boolean;
+  /**
+   * Maximum amount of peers allowed into the room
+   * @type {number}
+   * @memberof RoomConfig
+   */
+  maxPeers?: number | null;
+  /**
+   * True if livestream viewers can omit specifying a token.
+   * @type {boolean}
+   * @memberof RoomConfig
+   */
+  public?: boolean;
+  /**
+   *
+   * @type {RoomType}
+   * @memberof RoomConfig
+   */
+  roomType?: RoomType;
+  /**
+   *
+   * @type {VideoCodec}
+   * @memberof RoomConfig
+   */
+  videoCodec?: VideoCodec;
+  /**
+   * URL where Fishjam notifications will be sent
+   * @type {string}
+   * @memberof RoomConfig
+   */
+  webhookUrl?: string | null;
 }
-
 
 /**
  * Response containing room details
@@ -458,25 +457,25 @@ export interface RoomConfig {
  * @interface RoomCreateDetailsResponse
  */
 export interface RoomCreateDetailsResponse {
-    /**
-     * 
-     * @type {RoomCreateDetailsResponseData}
-     * @memberof RoomCreateDetailsResponse
-     */
-    'data': RoomCreateDetailsResponseData;
+  /**
+   *
+   * @type {RoomCreateDetailsResponseData}
+   * @memberof RoomCreateDetailsResponse
+   */
+  data: RoomCreateDetailsResponseData;
 }
 /**
- * 
+ *
  * @export
  * @interface RoomCreateDetailsResponseData
  */
 export interface RoomCreateDetailsResponseData {
-    /**
-     * 
-     * @type {Room}
-     * @memberof RoomCreateDetailsResponseData
-     */
-    'room': Room;
+  /**
+   *
+   * @type {Room}
+   * @memberof RoomCreateDetailsResponseData
+   */
+  room: Room;
 }
 /**
  * Response containing room details
@@ -484,12 +483,12 @@ export interface RoomCreateDetailsResponseData {
  * @interface RoomDetailsResponse
  */
 export interface RoomDetailsResponse {
-    /**
-     * 
-     * @type {Room}
-     * @memberof RoomDetailsResponse
-     */
-    'data': Room;
+  /**
+   *
+   * @type {Room}
+   * @memberof RoomDetailsResponse
+   */
+  data: Room;
 }
 /**
  * The use-case of the room. If not provided, this defaults to conference.
@@ -498,16 +497,15 @@ export interface RoomDetailsResponse {
  */
 
 export const RoomType = {
-    FullFeature: 'full_feature',
-    AudioOnly: 'audio_only',
-    Broadcaster: 'broadcaster',
-    Livestream: 'livestream',
-    Conference: 'conference',
-    AudioOnlyLivestream: 'audio_only_livestream'
+  FullFeature: 'full_feature',
+  AudioOnly: 'audio_only',
+  Broadcaster: 'broadcaster',
+  Livestream: 'livestream',
+  Conference: 'conference',
+  AudioOnlyLivestream: 'audio_only_livestream',
 } as const;
 
-export type RoomType = typeof RoomType[keyof typeof RoomType];
-
+export type RoomType = (typeof RoomType)[keyof typeof RoomType];
 
 /**
  * Response containing list of all rooms
@@ -515,12 +513,12 @@ export type RoomType = typeof RoomType[keyof typeof RoomType];
  * @interface RoomsListingResponse
  */
 export interface RoomsListingResponse {
-    /**
-     * 
-     * @type {Array<Room>}
-     * @memberof RoomsListingResponse
-     */
-    'data': Array<Room>;
+  /**
+   *
+   * @type {Array<Room>}
+   * @memberof RoomsListingResponse
+   */
+  data: Array<Room>;
 }
 /**
  * State of a stream
@@ -528,36 +526,36 @@ export interface RoomsListingResponse {
  * @interface Stream
  */
 export interface Stream {
-    /**
-     * True if stream is restricted to audio only
-     * @type {boolean}
-     * @memberof Stream
-     */
-    'audioOnly'?: boolean;
-    /**
-     * Assigned stream id
-     * @type {string}
-     * @memberof Stream
-     */
-    'id': string;
-    /**
-     * True if livestream viewers can omit specifying a token.
-     * @type {boolean}
-     * @memberof Stream
-     */
-    'public': boolean;
-    /**
-     * List of all streamers
-     * @type {Array<Streamer>}
-     * @memberof Stream
-     */
-    'streamers': Array<Streamer>;
-    /**
-     * List of all viewers
-     * @type {Array<Viewer>}
-     * @memberof Stream
-     */
-    'viewers': Array<Viewer>;
+  /**
+   * True if stream is restricted to audio only
+   * @type {boolean}
+   * @memberof Stream
+   */
+  audioOnly?: boolean;
+  /**
+   * Assigned stream id
+   * @type {string}
+   * @memberof Stream
+   */
+  id: string;
+  /**
+   * True if livestream viewers can omit specifying a token.
+   * @type {boolean}
+   * @memberof Stream
+   */
+  public: boolean;
+  /**
+   * List of all streamers
+   * @type {Array<Streamer>}
+   * @memberof Stream
+   */
+  streamers: Array<Streamer>;
+  /**
+   * List of all viewers
+   * @type {Array<Viewer>}
+   * @memberof Stream
+   */
+  viewers: Array<Viewer>;
 }
 /**
  * Stream configuration
@@ -565,30 +563,30 @@ export interface Stream {
  * @interface StreamConfig
  */
 export interface StreamConfig {
-    /**
-     * Restrics stream to audio only
-     * @type {boolean}
-     * @memberof StreamConfig
-     */
-    'audioOnly'?: boolean | null;
-    /**
-     * If true, webhook notifications for this stream are coalesced into a single NotificationBatch per HTTP send instead of one request per notification. VAD notifications are unaffected.
-     * @type {boolean}
-     * @memberof StreamConfig
-     */
-    'batchWebhookNotifications'?: boolean;
-    /**
-     * True if livestream viewers can omit specifying a token.
-     * @type {boolean}
-     * @memberof StreamConfig
-     */
-    'public'?: boolean;
-    /**
-     * Webhook URL for receiving server notifications
-     * @type {string}
-     * @memberof StreamConfig
-     */
-    'webhookUrl'?: string | null;
+  /**
+   * Restrics stream to audio only
+   * @type {boolean}
+   * @memberof StreamConfig
+   */
+  audioOnly?: boolean | null;
+  /**
+   * If true, webhook notifications for this stream are coalesced into a single NotificationBatch per HTTP send instead of one request per notification. VAD notifications are unaffected.
+   * @type {boolean}
+   * @memberof StreamConfig
+   */
+  batchWebhookNotifications?: boolean;
+  /**
+   * True if livestream viewers can omit specifying a token.
+   * @type {boolean}
+   * @memberof StreamConfig
+   */
+  public?: boolean;
+  /**
+   * Webhook URL for receiving server notifications
+   * @type {string}
+   * @memberof StreamConfig
+   */
+  webhookUrl?: string | null;
 }
 /**
  * Response containing stream details
@@ -596,12 +594,12 @@ export interface StreamConfig {
  * @interface StreamDetailsResponse
  */
 export interface StreamDetailsResponse {
-    /**
-     * 
-     * @type {Stream}
-     * @memberof StreamDetailsResponse
-     */
-    'data': Stream;
+  /**
+   *
+   * @type {Stream}
+   * @memberof StreamDetailsResponse
+   */
+  data: Stream;
 }
 /**
  * Describes streamer status
@@ -609,32 +607,32 @@ export interface StreamDetailsResponse {
  * @interface Streamer
  */
 export interface Streamer {
-    /**
-     * Assigned streamer id
-     * @type {string}
-     * @memberof Streamer
-     */
-    'id': string;
-    /**
-     * Streamer connection status
-     * @type {string}
-     * @memberof Streamer
-     */
-    'status': StreamerStatusEnum;
-    /**
-     * Token streamer should authorize with
-     * @type {string}
-     * @memberof Streamer
-     */
-    'token': string;
+  /**
+   * Assigned streamer id
+   * @type {string}
+   * @memberof Streamer
+   */
+  id: string;
+  /**
+   * Streamer connection status
+   * @type {string}
+   * @memberof Streamer
+   */
+  status: StreamerStatusEnum;
+  /**
+   * Token streamer should authorize with
+   * @type {string}
+   * @memberof Streamer
+   */
+  token: string;
 }
 
 export const StreamerStatusEnum = {
-    Connected: 'connected',
-    Disconnected: 'disconnected'
+  Connected: 'connected',
+  Disconnected: 'disconnected',
 } as const;
 
-export type StreamerStatusEnum = typeof StreamerStatusEnum[keyof typeof StreamerStatusEnum];
+export type StreamerStatusEnum = (typeof StreamerStatusEnum)[keyof typeof StreamerStatusEnum];
 
 /**
  * Response containing streamer details
@@ -642,12 +640,12 @@ export type StreamerStatusEnum = typeof StreamerStatusEnum[keyof typeof Streamer
  * @interface StreamerDetailsResponse
  */
 export interface StreamerDetailsResponse {
-    /**
-     * 
-     * @type {Streamer}
-     * @memberof StreamerDetailsResponse
-     */
-    'data': Streamer;
+  /**
+   *
+   * @type {Streamer}
+   * @memberof StreamerDetailsResponse
+   */
+  data: Streamer;
 }
 /**
  * Streamer authorization token
@@ -655,12 +653,12 @@ export interface StreamerDetailsResponse {
  * @interface StreamerToken
  */
 export interface StreamerToken {
-    /**
-     * Token streamer should authorize with
-     * @type {string}
-     * @memberof StreamerToken
-     */
-    'token': string;
+  /**
+   * Token streamer should authorize with
+   * @type {string}
+   * @memberof StreamerToken
+   */
+  token: string;
 }
 /**
  * Response containing list of all streams
@@ -668,12 +666,12 @@ export interface StreamerToken {
  * @interface StreamsListingResponse
  */
 export interface StreamsListingResponse {
-    /**
-     * 
-     * @type {Array<Stream>}
-     * @memberof StreamsListingResponse
-     */
-    'data': Array<Stream>;
+  /**
+   *
+   * @type {Array<Stream>}
+   * @memberof StreamsListingResponse
+   */
+  data: Array<Stream>;
 }
 /**
  * Configuration of peer\'s subscribing policy
@@ -682,25 +680,24 @@ export interface StreamsListingResponse {
  */
 
 export const SubscribeMode = {
-    Auto: 'auto',
-    Manual: 'manual'
+  Auto: 'auto',
+  Manual: 'manual',
 } as const;
 
-export type SubscribeMode = typeof SubscribeMode[keyof typeof SubscribeMode];
-
+export type SubscribeMode = (typeof SubscribeMode)[keyof typeof SubscribeMode];
 
 /**
- * 
+ *
  * @export
  * @interface SubscribeTracksRequest
  */
 export interface SubscribeTracksRequest {
-    /**
-     * List of track IDs to subscribe to
-     * @type {Array<string>}
-     * @memberof SubscribeTracksRequest
-     */
-    'track_ids': Array<string>;
+  /**
+   * List of track IDs to subscribe to
+   * @type {Array<string>}
+   * @memberof SubscribeTracksRequest
+   */
+  track_ids: Array<string>;
 }
 /**
  * Describes peer\'s subscriptions in manual mode
@@ -708,18 +705,18 @@ export interface SubscribeTracksRequest {
  * @interface Subscriptions
  */
 export interface Subscriptions {
-    /**
-     * List of peer IDs this peer subscribes to
-     * @type {Array<string>}
-     * @memberof Subscriptions
-     */
-    'peers': Array<string>;
-    /**
-     * List of track IDs this peer subscribes to
-     * @type {Array<string>}
-     * @memberof Subscriptions
-     */
-    'tracks': Array<string>;
+  /**
+   * List of peer IDs this peer subscribes to
+   * @type {Array<string>}
+   * @memberof Subscriptions
+   */
+  peers: Array<string>;
+  /**
+   * List of track IDs this peer subscribes to
+   * @type {Array<string>}
+   * @memberof Subscriptions
+   */
+  tracks: Array<string>;
 }
 /**
  * Media track of a Peer
@@ -727,26 +724,25 @@ export interface Subscriptions {
  * @interface Track
  */
 export interface Track {
-    /**
-     * Assigned track id
-     * @type {string}
-     * @memberof Track
-     */
-    'id'?: string;
-    /**
-     * Metadata attached to the track by the peer
-     * @type {object}
-     * @memberof Track
-     */
-    'metadata'?: object | null;
-    /**
-     * 
-     * @type {TrackType}
-     * @memberof Track
-     */
-    'type'?: TrackType;
+  /**
+   * Assigned track id
+   * @type {string}
+   * @memberof Track
+   */
+  id?: string;
+  /**
+   * Metadata attached to the track by the peer
+   * @type {object}
+   * @memberof Track
+   */
+  metadata?: object | null;
+  /**
+   *
+   * @type {TrackType}
+   * @memberof Track
+   */
+  type?: TrackType;
 }
-
 
 /**
  * Track forwardings for a room
@@ -754,18 +750,18 @@ export interface Track {
  * @interface TrackForwarding
  */
 export interface TrackForwarding {
-    /**
-     * URL for the composition
-     * @type {string}
-     * @memberof TrackForwarding
-     */
-    'compositionURL': string;
-    /**
-     * Selects tracks that should be forwarded, currently only \"all\" is supported
-     * @type {string}
-     * @memberof TrackForwarding
-     */
-    'selector'?: string;
+  /**
+   * URL for the composition
+   * @type {string}
+   * @memberof TrackForwarding
+   */
+  compositionURL: string;
+  /**
+   * Selects tracks that should be forwarded, currently only \"all\" is supported
+   * @type {string}
+   * @memberof TrackForwarding
+   */
+  selector?: string;
 }
 /**
  * Information about a track forwarding for a specific peer
@@ -773,30 +769,30 @@ export interface TrackForwarding {
  * @interface TrackForwardingInfo
  */
 export interface TrackForwardingInfo {
-    /**
-     * ID of the forwarded audio track
-     * @type {string}
-     * @memberof TrackForwardingInfo
-     */
-    'audioTrackId'?: string | null;
-    /**
-     * Input ID used by the composition
-     * @type {string}
-     * @memberof TrackForwardingInfo
-     */
-    'inputId': string;
-    /**
-     * Peer ID
-     * @type {string}
-     * @memberof TrackForwardingInfo
-     */
-    'peerId': string;
-    /**
-     * ID of the forwarded video track
-     * @type {string}
-     * @memberof TrackForwardingInfo
-     */
-    'videoTrackId'?: string | null;
+  /**
+   * ID of the forwarded audio track
+   * @type {string}
+   * @memberof TrackForwardingInfo
+   */
+  audioTrackId?: string | null;
+  /**
+   * Input ID used by the composition
+   * @type {string}
+   * @memberof TrackForwardingInfo
+   */
+  inputId: string;
+  /**
+   * Peer ID
+   * @type {string}
+   * @memberof TrackForwardingInfo
+   */
+  peerId: string;
+  /**
+   * ID of the forwarded video track
+   * @type {string}
+   * @memberof TrackForwardingInfo
+   */
+  videoTrackId?: string | null;
 }
 /**
  * Media type carried by the track
@@ -805,12 +801,11 @@ export interface TrackForwardingInfo {
  */
 
 export const TrackType = {
-    Audio: 'audio',
-    Video: 'video'
+  Audio: 'audio',
+  Video: 'video',
 } as const;
 
-export type TrackType = typeof TrackType[keyof typeof TrackType];
-
+export type TrackType = (typeof TrackType)[keyof typeof TrackType];
 
 /**
  * Enforces video codec for each peer in the room
@@ -819,12 +814,11 @@ export type TrackType = typeof TrackType[keyof typeof TrackType];
  */
 
 export const VideoCodec = {
-    H264: 'h264',
-    Vp8: 'vp8'
+  H264: 'h264',
+  Vp8: 'vp8',
 } as const;
 
-export type VideoCodec = typeof VideoCodec[keyof typeof VideoCodec];
-
+export type VideoCodec = (typeof VideoCodec)[keyof typeof VideoCodec];
 
 /**
  * Describes viewer status
@@ -832,18 +826,18 @@ export type VideoCodec = typeof VideoCodec[keyof typeof VideoCodec];
  * @interface Viewer
  */
 export interface Viewer {
-    /**
-     * Assigned viewer id
-     * @type {string}
-     * @memberof Viewer
-     */
-    'id': string;
-    /**
-     * Token viewer should authorize with
-     * @type {string}
-     * @memberof Viewer
-     */
-    'token': string;
+  /**
+   * Assigned viewer id
+   * @type {string}
+   * @memberof Viewer
+   */
+  id: string;
+  /**
+   * Token viewer should authorize with
+   * @type {string}
+   * @memberof Viewer
+   */
+  token: string;
 }
 /**
  * Response containing viewer details
@@ -851,12 +845,12 @@ export interface Viewer {
  * @interface ViewerDetailsResponse
  */
 export interface ViewerDetailsResponse {
-    /**
-     * 
-     * @type {Viewer}
-     * @memberof ViewerDetailsResponse
-     */
-    'data': Viewer;
+  /**
+   *
+   * @type {Viewer}
+   * @memberof ViewerDetailsResponse
+   */
+  data: Viewer;
 }
 /**
  * Viewer authorization token
@@ -864,12 +858,128 @@ export interface ViewerDetailsResponse {
  * @interface ViewerToken
  */
 export interface ViewerToken {
+  /**
+   * Token viewer should authorize with
+   * @type {string}
+   * @memberof ViewerToken
+   */
+  token: string;
+}
+
+/**
+ * CredentialsApi - axios parameter creator
+ * @export
+ */
+export const CredentialsApiAxiosParamCreator = function (configuration?: Configuration) {
+  return {
     /**
-     * Token viewer should authorize with
-     * @type {string}
-     * @memberof ViewerToken
+     * Returns 200 if the provided Fishjam Management Token is valid, 404 otherwise.
+     * @summary Validate Fishjam Management Token
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
      */
-    'token': string;
+    validateCredentials: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      const localVarPath = `/validate`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
+
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
+
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
+
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
+};
+
+/**
+ * CredentialsApi - functional programming interface
+ * @export
+ */
+export const CredentialsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = CredentialsApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Returns 200 if the provided Fishjam Management Token is valid, 404 otherwise.
+     * @summary Validate Fishjam Management Token
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async validateCredentials(
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.validateCredentials(options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['CredentialsApi.validateCredentials']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
+};
+
+/**
+ * CredentialsApi - factory interface
+ * @export
+ */
+export const CredentialsApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance
+) {
+  const localVarFp = CredentialsApiFp(configuration);
+  return {
+    /**
+     * Returns 200 if the provided Fishjam Management Token is valid, 404 otherwise.
+     * @summary Validate Fishjam Management Token
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    validateCredentials(options?: any): AxiosPromise<void> {
+      return localVarFp.validateCredentials(options).then((request) => request(axios, basePath));
+    },
+  };
+};
+
+/**
+ * CredentialsApi - object-oriented interface
+ * @export
+ * @class CredentialsApi
+ * @extends {BaseAPI}
+ */
+export class CredentialsApi extends BaseAPI {
+  /**
+   * Returns 200 if the provided Fishjam Management Token is valid, 404 otherwise.
+   * @summary Validate Fishjam Management Token
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof CredentialsApi
+   */
+  public validateCredentials(options?: RawAxiosRequestConfig) {
+    return CredentialsApiFp(this.configuration)
+      .validateCredentials(options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
 
 /**
@@ -877,69 +987,80 @@ export interface ViewerToken {
  * @export
  */
 export const MoQApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Issue a short-lived JWT for a Media over QUIC client.
-         * @summary Create a MoQ token
-         * @param {MoqTokenConfig} [moqTokenConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createMoqToken: async (moqTokenConfig?: MoqTokenConfig, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/moq/token`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+  return {
+    /**
+     * Issue a short-lived JWT for a Media over QUIC client.
+     * @summary Create a MoQ token
+     * @param {MoqTokenConfig} [moqTokenConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createMoqToken: async (
+      moqTokenConfig?: MoqTokenConfig,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      const localVarPath = `/moq/token`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
+      localVarHeaderParameter['Content-Type'] = 'application/json';
 
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+      localVarRequestOptions.data = serializeDataIfNeeded(moqTokenConfig, localVarRequestOptions, configuration);
 
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(moqTokenConfig, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
 };
 
 /**
  * MoQApi - functional programming interface
  * @export
  */
-export const MoQApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = MoQApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Issue a short-lived JWT for a Media over QUIC client.
-         * @summary Create a MoQ token
-         * @param {MoqTokenConfig} [moqTokenConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createMoqToken(moqTokenConfig?: MoqTokenConfig, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<MoqToken>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createMoqToken(moqTokenConfig, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['MoQApi.createMoqToken']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
+export const MoQApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = MoQApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Issue a short-lived JWT for a Media over QUIC client.
+     * @summary Create a MoQ token
+     * @param {MoqTokenConfig} [moqTokenConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async createMoqToken(
+      moqTokenConfig?: MoqTokenConfig,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<MoqToken>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.createMoqToken(moqTokenConfig, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['MoQApi.createMoqToken']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
 };
 
 /**
@@ -947,19 +1068,19 @@ export const MoQApiFp = function(configuration?: Configuration) {
  * @export
  */
 export const MoQApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = MoQApiFp(configuration)
-    return {
-        /**
-         * Issue a short-lived JWT for a Media over QUIC client.
-         * @summary Create a MoQ token
-         * @param {MoqTokenConfig} [moqTokenConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createMoqToken(moqTokenConfig?: MoqTokenConfig, options?: any): AxiosPromise<MoqToken> {
-            return localVarFp.createMoqToken(moqTokenConfig, options).then((request) => request(axios, basePath));
-        },
-    };
+  const localVarFp = MoQApiFp(configuration);
+  return {
+    /**
+     * Issue a short-lived JWT for a Media over QUIC client.
+     * @summary Create a MoQ token
+     * @param {MoqTokenConfig} [moqTokenConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createMoqToken(moqTokenConfig?: MoqTokenConfig, options?: any): AxiosPromise<MoqToken> {
+      return localVarFp.createMoqToken(moqTokenConfig, options).then((request) => request(axios, basePath));
+    },
+  };
 };
 
 /**
@@ -969,528 +1090,626 @@ export const MoQApiFactory = function (configuration?: Configuration, basePath?:
  * @extends {BaseAPI}
  */
 export class MoQApi extends BaseAPI {
-    /**
-     * Issue a short-lived JWT for a Media over QUIC client.
-     * @summary Create a MoQ token
-     * @param {MoqTokenConfig} [moqTokenConfig] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof MoQApi
-     */
-    public createMoqToken(moqTokenConfig?: MoqTokenConfig, options?: RawAxiosRequestConfig) {
-        return MoQApiFp(this.configuration).createMoqToken(moqTokenConfig, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Issue a short-lived JWT for a Media over QUIC client.
+   * @summary Create a MoQ token
+   * @param {MoqTokenConfig} [moqTokenConfig]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof MoQApi
+   */
+  public createMoqToken(moqTokenConfig?: MoqTokenConfig, options?: RawAxiosRequestConfig) {
+    return MoQApiFp(this.configuration)
+      .createMoqToken(moqTokenConfig, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
 
 /**
  * RoomsApi - axios parameter creator
  * @export
  */
 export const RoomsApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Add a peer to a room and return its connection token.
-         * @summary Create a peer
-         * @param {string} roomId Room id
-         * @param {PeerConfig} [peerConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        addPeer: async (roomId: string, peerConfig?: PeerConfig, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('addPeer', 'roomId', roomId)
-            const localVarPath = `/room/{room_id}/peer`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+  return {
+    /**
+     * Add a peer to a room and return its connection token.
+     * @summary Create a peer
+     * @param {string} roomId Room id
+     * @param {PeerConfig} [peerConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    addPeer: async (
+      roomId: string,
+      peerConfig?: PeerConfig,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('addPeer', 'roomId', roomId);
+      const localVarPath = `/room/{room_id}/peer`.replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
+      localVarHeaderParameter['Content-Type'] = 'application/json';
 
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+      localVarRequestOptions.data = serializeDataIfNeeded(peerConfig, localVarRequestOptions, configuration);
 
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(peerConfig, localVarRequestOptions, configuration)
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Create a new room with the given configuration.
+     * @summary Create a room
+     * @param {RoomConfig} [roomConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createRoom: async (roomConfig?: RoomConfig, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      const localVarPath = `/room`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Create a new room with the given configuration.
-         * @summary Create a room
-         * @param {RoomConfig} [roomConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createRoom: async (roomConfig?: RoomConfig, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/room`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      localVarHeaderParameter['Content-Type'] = 'application/json';
 
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+      localVarRequestOptions.data = serializeDataIfNeeded(roomConfig, localVarRequestOptions, configuration);
 
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Remove a peer from a room and disconnect it.
+     * @summary Delete a peer
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deletePeer: async (roomId: string, id: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('deletePeer', 'roomId', roomId);
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists('deletePeer', 'id', id);
+      const localVarPath = `/room/{room_id}/peer/{id}`
+        .replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)))
+        .replace(`{${'id'}}`, encodeURIComponent(String(id)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(roomConfig, localVarRequestOptions, configuration)
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Remove a peer from a room and disconnect it.
-         * @summary Delete a peer
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deletePeer: async (roomId: string, id: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('deletePeer', 'roomId', roomId)
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('deletePeer', 'id', id)
-            const localVarPath = `/room/{room_id}/peer/{id}`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)))
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Delete a room by id and disconnect all of its peers.
+     * @summary Delete a room
+     * @param {string} roomId Room id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteRoom: async (roomId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('deleteRoom', 'roomId', roomId);
+      const localVarPath = `/room/{room_id}`.replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Delete a room by id and disconnect all of its peers.
-         * @summary Delete a room
-         * @param {string} roomId Room id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteRoom: async (roomId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('deleteRoom', 'roomId', roomId)
-            const localVarPath = `/room/{room_id}`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * List all rooms and livestreams.
+     * @summary List all rooms
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getAllRooms: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      const localVarPath = `/room`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * List all rooms and livestreams.
-         * @summary List all rooms
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAllRooms: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/room`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Get a room by id.
+     * @summary Get a room
+     * @param {string} roomId Room ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getRoom: async (roomId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('getRoom', 'roomId', roomId);
+      const localVarPath = `/room/{room_id}`.replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Issue a fresh connection token for an existing peer.
+     * @summary Refresh a peer token
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    refreshToken: async (roomId: string, id: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('refreshToken', 'roomId', roomId);
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists('refreshToken', 'id', id);
+      const localVarPath = `/room/{room_id}/peer/{id}/refresh_token`
+        .replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)))
+        .replace(`{${'id'}}`, encodeURIComponent(String(id)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Get a room by id.
-         * @summary Get a room
-         * @param {string} roomId Room ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getRoom: async (roomId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('getRoom', 'roomId', roomId)
-            const localVarPath = `/room/{room_id}`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Subscribe a peer to all current and future tracks published by another peer in the same room.
+     * @summary Subscribe a peer to another peer\'s tracks
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {string} [peerId] ID of the peer that produces the track
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    subscribePeer: async (
+      roomId: string,
+      id: string,
+      peerId?: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('subscribePeer', 'roomId', roomId);
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists('subscribePeer', 'id', id);
+      const localVarPath = `/room/{room_id}/peer/{id}/subscribe_peer`
+        .replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)))
+        .replace(`{${'id'}}`, encodeURIComponent(String(id)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Issue a fresh connection token for an existing peer.
-         * @summary Refresh a peer token
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        refreshToken: async (roomId: string, id: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('refreshToken', 'roomId', roomId)
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('refreshToken', 'id', id)
-            const localVarPath = `/room/{room_id}/peer/{id}/refresh_token`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)))
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      if (peerId !== undefined) {
+        localVarQueryParameter['peer_id'] = peerId;
+      }
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Subscribe a peer to a specific list of track IDs in the same room.
+     * @summary Subscribe a peer to specific tracks
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {SubscribeTracksRequest} [subscribeTracksRequest] Track IDs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    subscribeTracks: async (
+      roomId: string,
+      id: string,
+      subscribeTracksRequest?: SubscribeTracksRequest,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('subscribeTracks', 'roomId', roomId);
+      // verify required parameter 'id' is not null or undefined
+      assertParamExists('subscribeTracks', 'id', id);
+      const localVarPath = `/room/{room_id}/peer/{id}/subscribe_tracks`
+        .replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)))
+        .replace(`{${'id'}}`, encodeURIComponent(String(id)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Subscribe a peer to all current and future tracks published by another peer in the same room.
-         * @summary Subscribe a peer to another peer\'s tracks
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {string} [peerId] ID of the peer that produces the track
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        subscribePeer: async (roomId: string, id: string, peerId?: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('subscribePeer', 'roomId', roomId)
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('subscribePeer', 'id', id)
-            const localVarPath = `/room/{room_id}/peer/{id}/subscribe_peer`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)))
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      localVarHeaderParameter['Content-Type'] = 'application/json';
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        subscribeTracksRequest,
+        localVarRequestOptions,
+        configuration
+      );
 
-            if (peerId !== undefined) {
-                localVarQueryParameter['peer_id'] = peerId;
-            }
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Subscribe a peer to a specific list of track IDs in the same room.
-         * @summary Subscribe a peer to specific tracks
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {SubscribeTracksRequest} [subscribeTracksRequest] Track IDs
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        subscribeTracks: async (roomId: string, id: string, subscribeTracksRequest?: SubscribeTracksRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('subscribeTracks', 'roomId', roomId)
-            // verify required parameter 'id' is not null or undefined
-            assertParamExists('subscribeTracks', 'id', id)
-            const localVarPath = `/room/{room_id}/peer/{id}/subscribe_tracks`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)))
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
-
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(subscribeTracksRequest, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
 };
 
 /**
  * RoomsApi - functional programming interface
  * @export
  */
-export const RoomsApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = RoomsApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Add a peer to a room and return its connection token.
-         * @summary Create a peer
-         * @param {string} roomId Room id
-         * @param {PeerConfig} [peerConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async addPeer(roomId: string, peerConfig?: PeerConfig, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PeerDetailsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.addPeer(roomId, peerConfig, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.addPeer']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Create a new room with the given configuration.
-         * @summary Create a room
-         * @param {RoomConfig} [roomConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createRoom(roomConfig?: RoomConfig, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RoomCreateDetailsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createRoom(roomConfig, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.createRoom']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Remove a peer from a room and disconnect it.
-         * @summary Delete a peer
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deletePeer(roomId: string, id: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deletePeer(roomId, id, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.deletePeer']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Delete a room by id and disconnect all of its peers.
-         * @summary Delete a room
-         * @param {string} roomId Room id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deleteRoom(roomId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteRoom(roomId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.deleteRoom']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * List all rooms and livestreams.
-         * @summary List all rooms
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getAllRooms(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RoomsListingResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllRooms(options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.getAllRooms']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Get a room by id.
-         * @summary Get a room
-         * @param {string} roomId Room ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getRoom(roomId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RoomDetailsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getRoom(roomId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.getRoom']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Issue a fresh connection token for an existing peer.
-         * @summary Refresh a peer token
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async refreshToken(roomId: string, id: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PeerRefreshTokenResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.refreshToken(roomId, id, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.refreshToken']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Subscribe a peer to all current and future tracks published by another peer in the same room.
-         * @summary Subscribe a peer to another peer\'s tracks
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {string} [peerId] ID of the peer that produces the track
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async subscribePeer(roomId: string, id: string, peerId?: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.subscribePeer(roomId, id, peerId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.subscribePeer']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Subscribe a peer to a specific list of track IDs in the same room.
-         * @summary Subscribe a peer to specific tracks
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {SubscribeTracksRequest} [subscribeTracksRequest] Track IDs
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async subscribeTracks(roomId: string, id: string, subscribeTracksRequest?: SubscribeTracksRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.subscribeTracks(roomId, id, subscribeTracksRequest, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['RoomsApi.subscribeTracks']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
+export const RoomsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = RoomsApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Add a peer to a room and return its connection token.
+     * @summary Create a peer
+     * @param {string} roomId Room id
+     * @param {PeerConfig} [peerConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async addPeer(
+      roomId: string,
+      peerConfig?: PeerConfig,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PeerDetailsResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.addPeer(roomId, peerConfig, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.addPeer']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Create a new room with the given configuration.
+     * @summary Create a room
+     * @param {RoomConfig} [roomConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async createRoom(
+      roomConfig?: RoomConfig,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RoomCreateDetailsResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.createRoom(roomConfig, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.createRoom']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Remove a peer from a room and disconnect it.
+     * @summary Delete a peer
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deletePeer(
+      roomId: string,
+      id: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deletePeer(roomId, id, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.deletePeer']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Delete a room by id and disconnect all of its peers.
+     * @summary Delete a room
+     * @param {string} roomId Room id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteRoom(
+      roomId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteRoom(roomId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.deleteRoom']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * List all rooms and livestreams.
+     * @summary List all rooms
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getAllRooms(
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RoomsListingResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getAllRooms(options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.getAllRooms']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Get a room by id.
+     * @summary Get a room
+     * @param {string} roomId Room ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getRoom(
+      roomId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<RoomDetailsResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getRoom(roomId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.getRoom']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Issue a fresh connection token for an existing peer.
+     * @summary Refresh a peer token
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async refreshToken(
+      roomId: string,
+      id: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PeerRefreshTokenResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.refreshToken(roomId, id, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.refreshToken']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Subscribe a peer to all current and future tracks published by another peer in the same room.
+     * @summary Subscribe a peer to another peer\'s tracks
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {string} [peerId] ID of the peer that produces the track
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async subscribePeer(
+      roomId: string,
+      id: string,
+      peerId?: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.subscribePeer(roomId, id, peerId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.subscribePeer']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Subscribe a peer to a specific list of track IDs in the same room.
+     * @summary Subscribe a peer to specific tracks
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {SubscribeTracksRequest} [subscribeTracksRequest] Track IDs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async subscribeTracks(
+      roomId: string,
+      id: string,
+      subscribeTracksRequest?: SubscribeTracksRequest,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.subscribeTracks(
+        roomId,
+        id,
+        subscribeTracksRequest,
+        options
+      );
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['RoomsApi.subscribeTracks']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
 };
 
 /**
@@ -1498,105 +1717,112 @@ export const RoomsApiFp = function(configuration?: Configuration) {
  * @export
  */
 export const RoomsApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = RoomsApiFp(configuration)
-    return {
-        /**
-         * Add a peer to a room and return its connection token.
-         * @summary Create a peer
-         * @param {string} roomId Room id
-         * @param {PeerConfig} [peerConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        addPeer(roomId: string, peerConfig?: PeerConfig, options?: any): AxiosPromise<PeerDetailsResponse> {
-            return localVarFp.addPeer(roomId, peerConfig, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Create a new room with the given configuration.
-         * @summary Create a room
-         * @param {RoomConfig} [roomConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createRoom(roomConfig?: RoomConfig, options?: any): AxiosPromise<RoomCreateDetailsResponse> {
-            return localVarFp.createRoom(roomConfig, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Remove a peer from a room and disconnect it.
-         * @summary Delete a peer
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deletePeer(roomId: string, id: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deletePeer(roomId, id, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Delete a room by id and disconnect all of its peers.
-         * @summary Delete a room
-         * @param {string} roomId Room id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteRoom(roomId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteRoom(roomId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * List all rooms and livestreams.
-         * @summary List all rooms
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAllRooms(options?: any): AxiosPromise<RoomsListingResponse> {
-            return localVarFp.getAllRooms(options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Get a room by id.
-         * @summary Get a room
-         * @param {string} roomId Room ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getRoom(roomId: string, options?: any): AxiosPromise<RoomDetailsResponse> {
-            return localVarFp.getRoom(roomId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Issue a fresh connection token for an existing peer.
-         * @summary Refresh a peer token
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        refreshToken(roomId: string, id: string, options?: any): AxiosPromise<PeerRefreshTokenResponse> {
-            return localVarFp.refreshToken(roomId, id, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Subscribe a peer to all current and future tracks published by another peer in the same room.
-         * @summary Subscribe a peer to another peer\'s tracks
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {string} [peerId] ID of the peer that produces the track
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        subscribePeer(roomId: string, id: string, peerId?: string, options?: any): AxiosPromise<void> {
-            return localVarFp.subscribePeer(roomId, id, peerId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Subscribe a peer to a specific list of track IDs in the same room.
-         * @summary Subscribe a peer to specific tracks
-         * @param {string} roomId Room id
-         * @param {string} id Peer id
-         * @param {SubscribeTracksRequest} [subscribeTracksRequest] Track IDs
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        subscribeTracks(roomId: string, id: string, subscribeTracksRequest?: SubscribeTracksRequest, options?: any): AxiosPromise<void> {
-            return localVarFp.subscribeTracks(roomId, id, subscribeTracksRequest, options).then((request) => request(axios, basePath));
-        },
-    };
+  const localVarFp = RoomsApiFp(configuration);
+  return {
+    /**
+     * Add a peer to a room and return its connection token.
+     * @summary Create a peer
+     * @param {string} roomId Room id
+     * @param {PeerConfig} [peerConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    addPeer(roomId: string, peerConfig?: PeerConfig, options?: any): AxiosPromise<PeerDetailsResponse> {
+      return localVarFp.addPeer(roomId, peerConfig, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Create a new room with the given configuration.
+     * @summary Create a room
+     * @param {RoomConfig} [roomConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createRoom(roomConfig?: RoomConfig, options?: any): AxiosPromise<RoomCreateDetailsResponse> {
+      return localVarFp.createRoom(roomConfig, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Remove a peer from a room and disconnect it.
+     * @summary Delete a peer
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deletePeer(roomId: string, id: string, options?: any): AxiosPromise<void> {
+      return localVarFp.deletePeer(roomId, id, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Delete a room by id and disconnect all of its peers.
+     * @summary Delete a room
+     * @param {string} roomId Room id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteRoom(roomId: string, options?: any): AxiosPromise<void> {
+      return localVarFp.deleteRoom(roomId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * List all rooms and livestreams.
+     * @summary List all rooms
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getAllRooms(options?: any): AxiosPromise<RoomsListingResponse> {
+      return localVarFp.getAllRooms(options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Get a room by id.
+     * @summary Get a room
+     * @param {string} roomId Room ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getRoom(roomId: string, options?: any): AxiosPromise<RoomDetailsResponse> {
+      return localVarFp.getRoom(roomId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Issue a fresh connection token for an existing peer.
+     * @summary Refresh a peer token
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    refreshToken(roomId: string, id: string, options?: any): AxiosPromise<PeerRefreshTokenResponse> {
+      return localVarFp.refreshToken(roomId, id, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Subscribe a peer to all current and future tracks published by another peer in the same room.
+     * @summary Subscribe a peer to another peer\'s tracks
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {string} [peerId] ID of the peer that produces the track
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    subscribePeer(roomId: string, id: string, peerId?: string, options?: any): AxiosPromise<void> {
+      return localVarFp.subscribePeer(roomId, id, peerId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Subscribe a peer to a specific list of track IDs in the same room.
+     * @summary Subscribe a peer to specific tracks
+     * @param {string} roomId Room id
+     * @param {string} id Peer id
+     * @param {SubscribeTracksRequest} [subscribeTracksRequest] Track IDs
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    subscribeTracks(
+      roomId: string,
+      id: string,
+      subscribeTracksRequest?: SubscribeTracksRequest,
+      options?: any
+    ): AxiosPromise<void> {
+      return localVarFp
+        .subscribeTracks(roomId, id, subscribeTracksRequest, options)
+        .then((request) => request(axios, basePath));
+    },
+  };
 };
 
 /**
@@ -1606,298 +1832,349 @@ export const RoomsApiFactory = function (configuration?: Configuration, basePath
  * @extends {BaseAPI}
  */
 export class RoomsApi extends BaseAPI {
-    /**
-     * Add a peer to a room and return its connection token.
-     * @summary Create a peer
-     * @param {string} roomId Room id
-     * @param {PeerConfig} [peerConfig] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public addPeer(roomId: string, peerConfig?: PeerConfig, options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).addPeer(roomId, peerConfig, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Add a peer to a room and return its connection token.
+   * @summary Create a peer
+   * @param {string} roomId Room id
+   * @param {PeerConfig} [peerConfig]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public addPeer(roomId: string, peerConfig?: PeerConfig, options?: RawAxiosRequestConfig) {
+    return RoomsApiFp(this.configuration)
+      .addPeer(roomId, peerConfig, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Create a new room with the given configuration.
-     * @summary Create a room
-     * @param {RoomConfig} [roomConfig] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public createRoom(roomConfig?: RoomConfig, options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).createRoom(roomConfig, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Create a new room with the given configuration.
+   * @summary Create a room
+   * @param {RoomConfig} [roomConfig]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public createRoom(roomConfig?: RoomConfig, options?: RawAxiosRequestConfig) {
+    return RoomsApiFp(this.configuration)
+      .createRoom(roomConfig, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Remove a peer from a room and disconnect it.
-     * @summary Delete a peer
-     * @param {string} roomId Room id
-     * @param {string} id Peer id
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public deletePeer(roomId: string, id: string, options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).deletePeer(roomId, id, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Remove a peer from a room and disconnect it.
+   * @summary Delete a peer
+   * @param {string} roomId Room id
+   * @param {string} id Peer id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public deletePeer(roomId: string, id: string, options?: RawAxiosRequestConfig) {
+    return RoomsApiFp(this.configuration)
+      .deletePeer(roomId, id, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Delete a room by id and disconnect all of its peers.
-     * @summary Delete a room
-     * @param {string} roomId Room id
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public deleteRoom(roomId: string, options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).deleteRoom(roomId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Delete a room by id and disconnect all of its peers.
+   * @summary Delete a room
+   * @param {string} roomId Room id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public deleteRoom(roomId: string, options?: RawAxiosRequestConfig) {
+    return RoomsApiFp(this.configuration)
+      .deleteRoom(roomId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * List all rooms and livestreams.
-     * @summary List all rooms
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public getAllRooms(options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).getAllRooms(options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * List all rooms and livestreams.
+   * @summary List all rooms
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public getAllRooms(options?: RawAxiosRequestConfig) {
+    return RoomsApiFp(this.configuration)
+      .getAllRooms(options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Get a room by id.
-     * @summary Get a room
-     * @param {string} roomId Room ID
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public getRoom(roomId: string, options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).getRoom(roomId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Get a room by id.
+   * @summary Get a room
+   * @param {string} roomId Room ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public getRoom(roomId: string, options?: RawAxiosRequestConfig) {
+    return RoomsApiFp(this.configuration)
+      .getRoom(roomId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Issue a fresh connection token for an existing peer.
-     * @summary Refresh a peer token
-     * @param {string} roomId Room id
-     * @param {string} id Peer id
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public refreshToken(roomId: string, id: string, options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).refreshToken(roomId, id, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Issue a fresh connection token for an existing peer.
+   * @summary Refresh a peer token
+   * @param {string} roomId Room id
+   * @param {string} id Peer id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public refreshToken(roomId: string, id: string, options?: RawAxiosRequestConfig) {
+    return RoomsApiFp(this.configuration)
+      .refreshToken(roomId, id, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Subscribe a peer to all current and future tracks published by another peer in the same room.
-     * @summary Subscribe a peer to another peer\'s tracks
-     * @param {string} roomId Room id
-     * @param {string} id Peer id
-     * @param {string} [peerId] ID of the peer that produces the track
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public subscribePeer(roomId: string, id: string, peerId?: string, options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).subscribePeer(roomId, id, peerId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Subscribe a peer to all current and future tracks published by another peer in the same room.
+   * @summary Subscribe a peer to another peer\'s tracks
+   * @param {string} roomId Room id
+   * @param {string} id Peer id
+   * @param {string} [peerId] ID of the peer that produces the track
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public subscribePeer(roomId: string, id: string, peerId?: string, options?: RawAxiosRequestConfig) {
+    return RoomsApiFp(this.configuration)
+      .subscribePeer(roomId, id, peerId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Subscribe a peer to a specific list of track IDs in the same room.
-     * @summary Subscribe a peer to specific tracks
-     * @param {string} roomId Room id
-     * @param {string} id Peer id
-     * @param {SubscribeTracksRequest} [subscribeTracksRequest] Track IDs
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof RoomsApi
-     */
-    public subscribeTracks(roomId: string, id: string, subscribeTracksRequest?: SubscribeTracksRequest, options?: RawAxiosRequestConfig) {
-        return RoomsApiFp(this.configuration).subscribeTracks(roomId, id, subscribeTracksRequest, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Subscribe a peer to a specific list of track IDs in the same room.
+   * @summary Subscribe a peer to specific tracks
+   * @param {string} roomId Room id
+   * @param {string} id Peer id
+   * @param {SubscribeTracksRequest} [subscribeTracksRequest] Track IDs
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof RoomsApi
+   */
+  public subscribeTracks(
+    roomId: string,
+    id: string,
+    subscribeTracksRequest?: SubscribeTracksRequest,
+    options?: RawAxiosRequestConfig
+  ) {
+    return RoomsApiFp(this.configuration)
+      .subscribeTracks(roomId, id, subscribeTracksRequest, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
 
 /**
  * StreamersApi - axios parameter creator
  * @export
  */
 export const StreamersApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Create a streamer for a stream and return its credentials.
-         * @summary Create a streamer
-         * @param {string} streamId Stream id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createStreamer: async (streamId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'streamId' is not null or undefined
-            assertParamExists('createStreamer', 'streamId', streamId)
-            const localVarPath = `/livestream/{stream_id}/streamer`
-                .replace(`{${"stream_id"}}`, encodeURIComponent(String(streamId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+  return {
+    /**
+     * Create a streamer for a stream and return its credentials.
+     * @summary Create a streamer
+     * @param {string} streamId Stream id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createStreamer: async (streamId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'streamId' is not null or undefined
+      assertParamExists('createStreamer', 'streamId', streamId);
+      const localVarPath = `/livestream/{stream_id}/streamer`.replace(
+        `{${'stream_id'}}`,
+        encodeURIComponent(String(streamId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Delete a streamer from a stream and revoke its token.
+     * @summary Delete a streamer
+     * @param {string} streamId Stream id
+     * @param {string} streamerId Streamer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteStreamer: async (
+      streamId: string,
+      streamerId: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'streamId' is not null or undefined
+      assertParamExists('deleteStreamer', 'streamId', streamId);
+      // verify required parameter 'streamerId' is not null or undefined
+      assertParamExists('deleteStreamer', 'streamerId', streamerId);
+      const localVarPath = `/livestream/{stream_id}/streamer/{streamer_id}`
+        .replace(`{${'stream_id'}}`, encodeURIComponent(String(streamId)))
+        .replace(`{${'streamer_id'}}`, encodeURIComponent(String(streamerId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Delete a streamer from a stream and revoke its token.
-         * @summary Delete a streamer
-         * @param {string} streamId Stream id
-         * @param {string} streamerId Streamer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteStreamer: async (streamId: string, streamerId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'streamId' is not null or undefined
-            assertParamExists('deleteStreamer', 'streamId', streamId)
-            // verify required parameter 'streamerId' is not null or undefined
-            assertParamExists('deleteStreamer', 'streamerId', streamerId)
-            const localVarPath = `/livestream/{stream_id}/streamer/{streamer_id}`
-                .replace(`{${"stream_id"}}`, encodeURIComponent(String(streamId)))
-                .replace(`{${"streamer_id"}}`, encodeURIComponent(String(streamerId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Issue a fresh streamer token.
+     * @summary Create a streamer token
+     * @param {string} roomId ID of the stream.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    generateStreamerToken: async (roomId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('generateStreamerToken', 'roomId', roomId);
+      const localVarPath = `/room/{room_id}/streamer`.replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Issue a fresh streamer token.
-         * @summary Create a streamer token
-         * @param {string} roomId ID of the stream.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        generateStreamerToken: async (roomId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('generateStreamerToken', 'roomId', roomId)
-            const localVarPath = `/room/{room_id}/streamer`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
 };
 
 /**
  * StreamersApi - functional programming interface
  * @export
  */
-export const StreamersApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = StreamersApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Create a streamer for a stream and return its credentials.
-         * @summary Create a streamer
-         * @param {string} streamId Stream id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createStreamer(streamId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamerDetailsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createStreamer(streamId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StreamersApi.createStreamer']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Delete a streamer from a stream and revoke its token.
-         * @summary Delete a streamer
-         * @param {string} streamId Stream id
-         * @param {string} streamerId Streamer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deleteStreamer(streamId: string, streamerId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteStreamer(streamId, streamerId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StreamersApi.deleteStreamer']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Issue a fresh streamer token.
-         * @summary Create a streamer token
-         * @param {string} roomId ID of the stream.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async generateStreamerToken(roomId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamerToken>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.generateStreamerToken(roomId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StreamersApi.generateStreamerToken']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
+export const StreamersApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = StreamersApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Create a streamer for a stream and return its credentials.
+     * @summary Create a streamer
+     * @param {string} streamId Stream id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async createStreamer(
+      streamId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamerDetailsResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.createStreamer(streamId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['StreamersApi.createStreamer']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Delete a streamer from a stream and revoke its token.
+     * @summary Delete a streamer
+     * @param {string} streamId Stream id
+     * @param {string} streamerId Streamer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteStreamer(
+      streamId: string,
+      streamerId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteStreamer(streamId, streamerId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['StreamersApi.deleteStreamer']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Issue a fresh streamer token.
+     * @summary Create a streamer token
+     * @param {string} roomId ID of the stream.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async generateStreamerToken(
+      roomId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamerToken>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.generateStreamerToken(roomId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['StreamersApi.generateStreamerToken']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
 };
 
 /**
@@ -1905,40 +2182,40 @@ export const StreamersApiFp = function(configuration?: Configuration) {
  * @export
  */
 export const StreamersApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = StreamersApiFp(configuration)
-    return {
-        /**
-         * Create a streamer for a stream and return its credentials.
-         * @summary Create a streamer
-         * @param {string} streamId Stream id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createStreamer(streamId: string, options?: any): AxiosPromise<StreamerDetailsResponse> {
-            return localVarFp.createStreamer(streamId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Delete a streamer from a stream and revoke its token.
-         * @summary Delete a streamer
-         * @param {string} streamId Stream id
-         * @param {string} streamerId Streamer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteStreamer(streamId: string, streamerId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteStreamer(streamId, streamerId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Issue a fresh streamer token.
-         * @summary Create a streamer token
-         * @param {string} roomId ID of the stream.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        generateStreamerToken(roomId: string, options?: any): AxiosPromise<StreamerToken> {
-            return localVarFp.generateStreamerToken(roomId, options).then((request) => request(axios, basePath));
-        },
-    };
+  const localVarFp = StreamersApiFp(configuration);
+  return {
+    /**
+     * Create a streamer for a stream and return its credentials.
+     * @summary Create a streamer
+     * @param {string} streamId Stream id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createStreamer(streamId: string, options?: any): AxiosPromise<StreamerDetailsResponse> {
+      return localVarFp.createStreamer(streamId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Delete a streamer from a stream and revoke its token.
+     * @summary Delete a streamer
+     * @param {string} streamId Stream id
+     * @param {string} streamerId Streamer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteStreamer(streamId: string, streamerId: string, options?: any): AxiosPromise<void> {
+      return localVarFp.deleteStreamer(streamId, streamerId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Issue a fresh streamer token.
+     * @summary Create a streamer token
+     * @param {string} roomId ID of the stream.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    generateStreamerToken(roomId: string, options?: any): AxiosPromise<StreamerToken> {
+      return localVarFp.generateStreamerToken(roomId, options).then((request) => request(axios, basePath));
+    },
+  };
 };
 
 /**
@@ -1948,262 +2225,295 @@ export const StreamersApiFactory = function (configuration?: Configuration, base
  * @extends {BaseAPI}
  */
 export class StreamersApi extends BaseAPI {
-    /**
-     * Create a streamer for a stream and return its credentials.
-     * @summary Create a streamer
-     * @param {string} streamId Stream id
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StreamersApi
-     */
-    public createStreamer(streamId: string, options?: RawAxiosRequestConfig) {
-        return StreamersApiFp(this.configuration).createStreamer(streamId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Create a streamer for a stream and return its credentials.
+   * @summary Create a streamer
+   * @param {string} streamId Stream id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof StreamersApi
+   */
+  public createStreamer(streamId: string, options?: RawAxiosRequestConfig) {
+    return StreamersApiFp(this.configuration)
+      .createStreamer(streamId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Delete a streamer from a stream and revoke its token.
-     * @summary Delete a streamer
-     * @param {string} streamId Stream id
-     * @param {string} streamerId Streamer id
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StreamersApi
-     */
-    public deleteStreamer(streamId: string, streamerId: string, options?: RawAxiosRequestConfig) {
-        return StreamersApiFp(this.configuration).deleteStreamer(streamId, streamerId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Delete a streamer from a stream and revoke its token.
+   * @summary Delete a streamer
+   * @param {string} streamId Stream id
+   * @param {string} streamerId Streamer id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof StreamersApi
+   */
+  public deleteStreamer(streamId: string, streamerId: string, options?: RawAxiosRequestConfig) {
+    return StreamersApiFp(this.configuration)
+      .deleteStreamer(streamId, streamerId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Issue a fresh streamer token.
-     * @summary Create a streamer token
-     * @param {string} roomId ID of the stream.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StreamersApi
-     */
-    public generateStreamerToken(roomId: string, options?: RawAxiosRequestConfig) {
-        return StreamersApiFp(this.configuration).generateStreamerToken(roomId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Issue a fresh streamer token.
+   * @summary Create a streamer token
+   * @param {string} roomId ID of the stream.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof StreamersApi
+   */
+  public generateStreamerToken(roomId: string, options?: RawAxiosRequestConfig) {
+    return StreamersApiFp(this.configuration)
+      .generateStreamerToken(roomId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
 
 /**
  * StreamsApi - axios parameter creator
  * @export
  */
 export const StreamsApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Create a new livestream with the given configuration.
-         * @summary Create a stream
-         * @param {StreamConfig} [streamConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createStream: async (streamConfig?: StreamConfig, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/livestream`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+  return {
+    /**
+     * Create a new livestream with the given configuration.
+     * @summary Create a stream
+     * @param {StreamConfig} [streamConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createStream: async (streamConfig?: StreamConfig, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      const localVarPath = `/livestream`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
+      localVarHeaderParameter['Content-Type'] = 'application/json';
 
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+      localVarRequestOptions.data = serializeDataIfNeeded(streamConfig, localVarRequestOptions, configuration);
 
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(streamConfig, localVarRequestOptions, configuration)
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Delete a stream by id and disconnect all of its streamers and viewers.
+     * @summary Delete a stream
+     * @param {string} streamId Stream ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteStream: async (streamId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'streamId' is not null or undefined
+      assertParamExists('deleteStream', 'streamId', streamId);
+      const localVarPath = `/livestream/{stream_id}`.replace(`{${'stream_id'}}`, encodeURIComponent(String(streamId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Delete a stream by id and disconnect all of its streamers and viewers.
-         * @summary Delete a stream
-         * @param {string} streamId Stream ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteStream: async (streamId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'streamId' is not null or undefined
-            assertParamExists('deleteStream', 'streamId', streamId)
-            const localVarPath = `/livestream/{stream_id}`
-                .replace(`{${"stream_id"}}`, encodeURIComponent(String(streamId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * List all livestreams.
+     * @summary List all streams
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getAllStreams: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      const localVarPath = `/livestream`;
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * List all livestreams.
-         * @summary List all streams
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAllStreams: async (options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            const localVarPath = `/livestream`;
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Get a stream by id.
+     * @summary Get a stream
+     * @param {string} streamId Stream ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getStream: async (streamId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'streamId' is not null or undefined
+      assertParamExists('getStream', 'streamId', streamId);
+      const localVarPath = `/livestream/{stream_id}`.replace(`{${'stream_id'}}`, encodeURIComponent(String(streamId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
+      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Get a stream by id.
-         * @summary Get a stream
-         * @param {string} streamId Stream ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStream: async (streamId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'streamId' is not null or undefined
-            assertParamExists('getStream', 'streamId', streamId)
-            const localVarPath = `/livestream/{stream_id}`
-                .replace(`{${"stream_id"}}`, encodeURIComponent(String(streamId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
 };
 
 /**
  * StreamsApi - functional programming interface
  * @export
  */
-export const StreamsApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = StreamsApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Create a new livestream with the given configuration.
-         * @summary Create a stream
-         * @param {StreamConfig} [streamConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createStream(streamConfig?: StreamConfig, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamDetailsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createStream(streamConfig, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StreamsApi.createStream']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Delete a stream by id and disconnect all of its streamers and viewers.
-         * @summary Delete a stream
-         * @param {string} streamId Stream ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deleteStream(streamId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteStream(streamId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StreamsApi.deleteStream']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * List all livestreams.
-         * @summary List all streams
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getAllStreams(options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamsListingResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getAllStreams(options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StreamsApi.getAllStreams']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Get a stream by id.
-         * @summary Get a stream
-         * @param {string} streamId Stream ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async getStream(streamId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamDetailsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.getStream(streamId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['StreamsApi.getStream']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
+export const StreamsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = StreamsApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Create a new livestream with the given configuration.
+     * @summary Create a stream
+     * @param {StreamConfig} [streamConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async createStream(
+      streamConfig?: StreamConfig,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamDetailsResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.createStream(streamConfig, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['StreamsApi.createStream']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Delete a stream by id and disconnect all of its streamers and viewers.
+     * @summary Delete a stream
+     * @param {string} streamId Stream ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteStream(
+      streamId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteStream(streamId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['StreamsApi.deleteStream']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * List all livestreams.
+     * @summary List all streams
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getAllStreams(
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamsListingResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getAllStreams(options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['StreamsApi.getAllStreams']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Get a stream by id.
+     * @summary Get a stream
+     * @param {string} streamId Stream ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async getStream(
+      streamId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<StreamDetailsResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.getStream(streamId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['StreamsApi.getStream']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
 };
 
 /**
@@ -2211,48 +2521,48 @@ export const StreamsApiFp = function(configuration?: Configuration) {
  * @export
  */
 export const StreamsApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = StreamsApiFp(configuration)
-    return {
-        /**
-         * Create a new livestream with the given configuration.
-         * @summary Create a stream
-         * @param {StreamConfig} [streamConfig] 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createStream(streamConfig?: StreamConfig, options?: any): AxiosPromise<StreamDetailsResponse> {
-            return localVarFp.createStream(streamConfig, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Delete a stream by id and disconnect all of its streamers and viewers.
-         * @summary Delete a stream
-         * @param {string} streamId Stream ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteStream(streamId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteStream(streamId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * List all livestreams.
-         * @summary List all streams
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getAllStreams(options?: any): AxiosPromise<StreamsListingResponse> {
-            return localVarFp.getAllStreams(options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Get a stream by id.
-         * @summary Get a stream
-         * @param {string} streamId Stream ID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getStream(streamId: string, options?: any): AxiosPromise<StreamDetailsResponse> {
-            return localVarFp.getStream(streamId, options).then((request) => request(axios, basePath));
-        },
-    };
+  const localVarFp = StreamsApiFp(configuration);
+  return {
+    /**
+     * Create a new livestream with the given configuration.
+     * @summary Create a stream
+     * @param {StreamConfig} [streamConfig]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createStream(streamConfig?: StreamConfig, options?: any): AxiosPromise<StreamDetailsResponse> {
+      return localVarFp.createStream(streamConfig, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Delete a stream by id and disconnect all of its streamers and viewers.
+     * @summary Delete a stream
+     * @param {string} streamId Stream ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteStream(streamId: string, options?: any): AxiosPromise<void> {
+      return localVarFp.deleteStream(streamId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * List all livestreams.
+     * @summary List all streams
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getAllStreams(options?: any): AxiosPromise<StreamsListingResponse> {
+      return localVarFp.getAllStreams(options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Get a stream by id.
+     * @summary Get a stream
+     * @param {string} streamId Stream ID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    getStream(streamId: string, options?: any): AxiosPromise<StreamDetailsResponse> {
+      return localVarFp.getStream(streamId, options).then((request) => request(axios, basePath));
+    },
+  };
 };
 
 /**
@@ -2262,152 +2572,179 @@ export const StreamsApiFactory = function (configuration?: Configuration, basePa
  * @extends {BaseAPI}
  */
 export class StreamsApi extends BaseAPI {
-    /**
-     * Create a new livestream with the given configuration.
-     * @summary Create a stream
-     * @param {StreamConfig} [streamConfig] 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StreamsApi
-     */
-    public createStream(streamConfig?: StreamConfig, options?: RawAxiosRequestConfig) {
-        return StreamsApiFp(this.configuration).createStream(streamConfig, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Create a new livestream with the given configuration.
+   * @summary Create a stream
+   * @param {StreamConfig} [streamConfig]
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof StreamsApi
+   */
+  public createStream(streamConfig?: StreamConfig, options?: RawAxiosRequestConfig) {
+    return StreamsApiFp(this.configuration)
+      .createStream(streamConfig, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Delete a stream by id and disconnect all of its streamers and viewers.
-     * @summary Delete a stream
-     * @param {string} streamId Stream ID
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StreamsApi
-     */
-    public deleteStream(streamId: string, options?: RawAxiosRequestConfig) {
-        return StreamsApiFp(this.configuration).deleteStream(streamId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Delete a stream by id and disconnect all of its streamers and viewers.
+   * @summary Delete a stream
+   * @param {string} streamId Stream ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof StreamsApi
+   */
+  public deleteStream(streamId: string, options?: RawAxiosRequestConfig) {
+    return StreamsApiFp(this.configuration)
+      .deleteStream(streamId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * List all livestreams.
-     * @summary List all streams
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StreamsApi
-     */
-    public getAllStreams(options?: RawAxiosRequestConfig) {
-        return StreamsApiFp(this.configuration).getAllStreams(options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * List all livestreams.
+   * @summary List all streams
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof StreamsApi
+   */
+  public getAllStreams(options?: RawAxiosRequestConfig) {
+    return StreamsApiFp(this.configuration)
+      .getAllStreams(options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Get a stream by id.
-     * @summary Get a stream
-     * @param {string} streamId Stream ID
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof StreamsApi
-     */
-    public getStream(streamId: string, options?: RawAxiosRequestConfig) {
-        return StreamsApiFp(this.configuration).getStream(streamId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Get a stream by id.
+   * @summary Get a stream
+   * @param {string} streamId Stream ID
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof StreamsApi
+   */
+  public getStream(streamId: string, options?: RawAxiosRequestConfig) {
+    return StreamsApiFp(this.configuration)
+      .getStream(streamId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
 
 /**
  * TrackForwardingsApi - axios parameter creator
  * @export
  */
 export const TrackForwardingsApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Forward a room\'s tracks into an external composition.
-         * @summary Create a track forwarding
-         * @param {string} roomId Room id
-         * @param {TrackForwarding} trackForwarding 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createTrackForwarding: async (roomId: string, trackForwarding: TrackForwarding, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('createTrackForwarding', 'roomId', roomId)
-            // verify required parameter 'trackForwarding' is not null or undefined
-            assertParamExists('createTrackForwarding', 'trackForwarding', trackForwarding)
-            const localVarPath = `/room/{room_id}/track_forwardings`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+  return {
+    /**
+     * Forward a room\'s tracks into an external composition.
+     * @summary Create a track forwarding
+     * @param {string} roomId Room id
+     * @param {TrackForwarding} trackForwarding
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createTrackForwarding: async (
+      roomId: string,
+      trackForwarding: TrackForwarding,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('createTrackForwarding', 'roomId', roomId);
+      // verify required parameter 'trackForwarding' is not null or undefined
+      assertParamExists('createTrackForwarding', 'trackForwarding', trackForwarding);
+      const localVarPath = `/room/{room_id}/track_forwardings`.replace(
+        `{${'room_id'}}`,
+        encodeURIComponent(String(roomId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
+      localVarHeaderParameter['Content-Type'] = 'application/json';
 
-    
-            localVarHeaderParameter['Content-Type'] = 'application/json';
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
+      localVarRequestOptions.data = serializeDataIfNeeded(trackForwarding, localVarRequestOptions, configuration);
 
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(trackForwarding, localVarRequestOptions, configuration)
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
 };
 
 /**
  * TrackForwardingsApi - functional programming interface
  * @export
  */
-export const TrackForwardingsApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = TrackForwardingsApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Forward a room\'s tracks into an external composition.
-         * @summary Create a track forwarding
-         * @param {string} roomId Room id
-         * @param {TrackForwarding} trackForwarding 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createTrackForwarding(roomId: string, trackForwarding: TrackForwarding, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createTrackForwarding(roomId, trackForwarding, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['TrackForwardingsApi.createTrackForwarding']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
+export const TrackForwardingsApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = TrackForwardingsApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Forward a room\'s tracks into an external composition.
+     * @summary Create a track forwarding
+     * @param {string} roomId Room id
+     * @param {TrackForwarding} trackForwarding
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async createTrackForwarding(
+      roomId: string,
+      trackForwarding: TrackForwarding,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.createTrackForwarding(roomId, trackForwarding, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['TrackForwardingsApi.createTrackForwarding']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
 };
 
 /**
  * TrackForwardingsApi - factory interface
  * @export
  */
-export const TrackForwardingsApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = TrackForwardingsApiFp(configuration)
-    return {
-        /**
-         * Forward a room\'s tracks into an external composition.
-         * @summary Create a track forwarding
-         * @param {string} roomId Room id
-         * @param {TrackForwarding} trackForwarding 
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createTrackForwarding(roomId: string, trackForwarding: TrackForwarding, options?: any): AxiosPromise<void> {
-            return localVarFp.createTrackForwarding(roomId, trackForwarding, options).then((request) => request(axios, basePath));
-        },
-    };
+export const TrackForwardingsApiFactory = function (
+  configuration?: Configuration,
+  basePath?: string,
+  axios?: AxiosInstance
+) {
+  const localVarFp = TrackForwardingsApiFp(configuration);
+  return {
+    /**
+     * Forward a room\'s tracks into an external composition.
+     * @summary Create a track forwarding
+     * @param {string} roomId Room id
+     * @param {TrackForwarding} trackForwarding
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createTrackForwarding(roomId: string, trackForwarding: TrackForwarding, options?: any): AxiosPromise<void> {
+      return localVarFp
+        .createTrackForwarding(roomId, trackForwarding, options)
+        .then((request) => request(axios, basePath));
+    },
+  };
 };
 
 /**
@@ -2417,197 +2754,227 @@ export const TrackForwardingsApiFactory = function (configuration?: Configuratio
  * @extends {BaseAPI}
  */
 export class TrackForwardingsApi extends BaseAPI {
-    /**
-     * Forward a room\'s tracks into an external composition.
-     * @summary Create a track forwarding
-     * @param {string} roomId Room id
-     * @param {TrackForwarding} trackForwarding 
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof TrackForwardingsApi
-     */
-    public createTrackForwarding(roomId: string, trackForwarding: TrackForwarding, options?: RawAxiosRequestConfig) {
-        return TrackForwardingsApiFp(this.configuration).createTrackForwarding(roomId, trackForwarding, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Forward a room\'s tracks into an external composition.
+   * @summary Create a track forwarding
+   * @param {string} roomId Room id
+   * @param {TrackForwarding} trackForwarding
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof TrackForwardingsApi
+   */
+  public createTrackForwarding(roomId: string, trackForwarding: TrackForwarding, options?: RawAxiosRequestConfig) {
+    return TrackForwardingsApiFp(this.configuration)
+      .createTrackForwarding(roomId, trackForwarding, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
 
 /**
  * ViewersApi - axios parameter creator
  * @export
  */
 export const ViewersApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         * Create a viewer for a stream and return its credentials.
-         * @summary Create a viewer
-         * @param {string} streamId Stream id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createViewer: async (streamId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'streamId' is not null or undefined
-            assertParamExists('createViewer', 'streamId', streamId)
-            const localVarPath = `/livestream/{stream_id}/viewer`
-                .replace(`{${"stream_id"}}`, encodeURIComponent(String(streamId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+  return {
+    /**
+     * Create a viewer for a stream and return its credentials.
+     * @summary Create a viewer
+     * @param {string} streamId Stream id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createViewer: async (streamId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'streamId' is not null or undefined
+      assertParamExists('createViewer', 'streamId', streamId);
+      const localVarPath = `/livestream/{stream_id}/viewer`.replace(
+        `{${'stream_id'}}`,
+        encodeURIComponent(String(streamId))
+      );
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Delete a viewer from a stream and revoke its token.
+     * @summary Delete a viewer
+     * @param {string} streamId Stream id
+     * @param {string} viewerId Viewer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteViewer: async (
+      streamId: string,
+      viewerId: string,
+      options: RawAxiosRequestConfig = {}
+    ): Promise<RequestArgs> => {
+      // verify required parameter 'streamId' is not null or undefined
+      assertParamExists('deleteViewer', 'streamId', streamId);
+      // verify required parameter 'viewerId' is not null or undefined
+      assertParamExists('deleteViewer', 'viewerId', viewerId);
+      const localVarPath = `/livestream/{stream_id}/viewer/{viewer_id}`
+        .replace(`{${'stream_id'}}`, encodeURIComponent(String(streamId)))
+        .replace(`{${'viewer_id'}}`, encodeURIComponent(String(viewerId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Delete a viewer from a stream and revoke its token.
-         * @summary Delete a viewer
-         * @param {string} streamId Stream id
-         * @param {string} viewerId Viewer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteViewer: async (streamId: string, viewerId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'streamId' is not null or undefined
-            assertParamExists('deleteViewer', 'streamId', streamId)
-            // verify required parameter 'viewerId' is not null or undefined
-            assertParamExists('deleteViewer', 'viewerId', viewerId)
-            const localVarPath = `/livestream/{stream_id}/viewer/{viewer_id}`
-                .replace(`{${"stream_id"}}`, encodeURIComponent(String(streamId)))
-                .replace(`{${"viewer_id"}}`, encodeURIComponent(String(viewerId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            const localVarRequestOptions = { method: 'DELETE', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+    /**
+     * Issue a fresh viewer token.
+     * @summary Create a viewer token
+     * @param {string} roomId ID of the stream.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    generateViewerToken: async (roomId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+      // verify required parameter 'roomId' is not null or undefined
+      assertParamExists('generateViewerToken', 'roomId', roomId);
+      const localVarPath = `/room/{room_id}/viewer`.replace(`{${'room_id'}}`, encodeURIComponent(String(roomId)));
+      // use dummy base URL string because the URL constructor only accepts absolute URLs.
+      const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+      let baseOptions;
+      if (configuration) {
+        baseOptions = configuration.baseOptions;
+      }
 
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+      const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options };
+      const localVarHeaderParameter = {} as any;
+      const localVarQueryParameter = {} as any;
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         * Issue a fresh viewer token.
-         * @summary Create a viewer token
-         * @param {string} roomId ID of the stream.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        generateViewerToken: async (roomId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'roomId' is not null or undefined
-            assertParamExists('generateViewerToken', 'roomId', roomId)
-            const localVarPath = `/room/{room_id}/viewer`
-                .replace(`{${"room_id"}}`, encodeURIComponent(String(roomId)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+      // authentication management_token required
+      // http bearer authentication required
+      await setBearerAuthToObject(localVarHeaderParameter, configuration);
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+      setSearchParams(localVarUrlObj, localVarQueryParameter);
+      let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+      localVarRequestOptions.headers = { ...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers };
 
-            // authentication management_token required
-            // http bearer authentication required
-            await setBearerAuthToObject(localVarHeaderParameter, configuration)
-
-
-    
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    }
+      return {
+        url: toPathString(localVarUrlObj),
+        options: localVarRequestOptions,
+      };
+    },
+  };
 };
 
 /**
  * ViewersApi - functional programming interface
  * @export
  */
-export const ViewersApiFp = function(configuration?: Configuration) {
-    const localVarAxiosParamCreator = ViewersApiAxiosParamCreator(configuration)
-    return {
-        /**
-         * Create a viewer for a stream and return its credentials.
-         * @summary Create a viewer
-         * @param {string} streamId Stream id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async createViewer(streamId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ViewerDetailsResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.createViewer(streamId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['ViewersApi.createViewer']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Delete a viewer from a stream and revoke its token.
-         * @summary Delete a viewer
-         * @param {string} streamId Stream id
-         * @param {string} viewerId Viewer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async deleteViewer(streamId: string, viewerId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.deleteViewer(streamId, viewerId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['ViewersApi.deleteViewer']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-        /**
-         * Issue a fresh viewer token.
-         * @summary Create a viewer token
-         * @param {string} roomId ID of the stream.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async generateViewerToken(roomId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ViewerToken>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.generateViewerToken(roomId, options);
-            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
-            const localVarOperationServerBasePath = operationServerMap['ViewersApi.generateViewerToken']?.[localVarOperationServerIndex]?.url;
-            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
-        },
-    }
+export const ViewersApiFp = function (configuration?: Configuration) {
+  const localVarAxiosParamCreator = ViewersApiAxiosParamCreator(configuration);
+  return {
+    /**
+     * Create a viewer for a stream and return its credentials.
+     * @summary Create a viewer
+     * @param {string} streamId Stream id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async createViewer(
+      streamId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ViewerDetailsResponse>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.createViewer(streamId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['ViewersApi.createViewer']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Delete a viewer from a stream and revoke its token.
+     * @summary Delete a viewer
+     * @param {string} streamId Stream id
+     * @param {string} viewerId Viewer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async deleteViewer(
+      streamId: string,
+      viewerId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.deleteViewer(streamId, viewerId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['ViewersApi.deleteViewer']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+    /**
+     * Issue a fresh viewer token.
+     * @summary Create a viewer token
+     * @param {string} roomId ID of the stream.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    async generateViewerToken(
+      roomId: string,
+      options?: RawAxiosRequestConfig
+    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<ViewerToken>> {
+      const localVarAxiosArgs = await localVarAxiosParamCreator.generateViewerToken(roomId, options);
+      const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+      const localVarOperationServerBasePath =
+        operationServerMap['ViewersApi.generateViewerToken']?.[localVarOperationServerIndex]?.url;
+      return (axios, basePath) =>
+        createRequestFunction(
+          localVarAxiosArgs,
+          globalAxios,
+          BASE_PATH,
+          configuration
+        )(axios, localVarOperationServerBasePath || basePath);
+    },
+  };
 };
 
 /**
@@ -2615,40 +2982,40 @@ export const ViewersApiFp = function(configuration?: Configuration) {
  * @export
  */
 export const ViewersApiFactory = function (configuration?: Configuration, basePath?: string, axios?: AxiosInstance) {
-    const localVarFp = ViewersApiFp(configuration)
-    return {
-        /**
-         * Create a viewer for a stream and return its credentials.
-         * @summary Create a viewer
-         * @param {string} streamId Stream id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createViewer(streamId: string, options?: any): AxiosPromise<ViewerDetailsResponse> {
-            return localVarFp.createViewer(streamId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Delete a viewer from a stream and revoke its token.
-         * @summary Delete a viewer
-         * @param {string} streamId Stream id
-         * @param {string} viewerId Viewer id
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteViewer(streamId: string, viewerId: string, options?: any): AxiosPromise<void> {
-            return localVarFp.deleteViewer(streamId, viewerId, options).then((request) => request(axios, basePath));
-        },
-        /**
-         * Issue a fresh viewer token.
-         * @summary Create a viewer token
-         * @param {string} roomId ID of the stream.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        generateViewerToken(roomId: string, options?: any): AxiosPromise<ViewerToken> {
-            return localVarFp.generateViewerToken(roomId, options).then((request) => request(axios, basePath));
-        },
-    };
+  const localVarFp = ViewersApiFp(configuration);
+  return {
+    /**
+     * Create a viewer for a stream and return its credentials.
+     * @summary Create a viewer
+     * @param {string} streamId Stream id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    createViewer(streamId: string, options?: any): AxiosPromise<ViewerDetailsResponse> {
+      return localVarFp.createViewer(streamId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Delete a viewer from a stream and revoke its token.
+     * @summary Delete a viewer
+     * @param {string} streamId Stream id
+     * @param {string} viewerId Viewer id
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    deleteViewer(streamId: string, viewerId: string, options?: any): AxiosPromise<void> {
+      return localVarFp.deleteViewer(streamId, viewerId, options).then((request) => request(axios, basePath));
+    },
+    /**
+     * Issue a fresh viewer token.
+     * @summary Create a viewer token
+     * @param {string} roomId ID of the stream.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    generateViewerToken(roomId: string, options?: any): AxiosPromise<ViewerToken> {
+      return localVarFp.generateViewerToken(roomId, options).then((request) => request(axios, basePath));
+    },
+  };
 };
 
 /**
@@ -2658,43 +3025,46 @@ export const ViewersApiFactory = function (configuration?: Configuration, basePa
  * @extends {BaseAPI}
  */
 export class ViewersApi extends BaseAPI {
-    /**
-     * Create a viewer for a stream and return its credentials.
-     * @summary Create a viewer
-     * @param {string} streamId Stream id
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof ViewersApi
-     */
-    public createViewer(streamId: string, options?: RawAxiosRequestConfig) {
-        return ViewersApiFp(this.configuration).createViewer(streamId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Create a viewer for a stream and return its credentials.
+   * @summary Create a viewer
+   * @param {string} streamId Stream id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof ViewersApi
+   */
+  public createViewer(streamId: string, options?: RawAxiosRequestConfig) {
+    return ViewersApiFp(this.configuration)
+      .createViewer(streamId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Delete a viewer from a stream and revoke its token.
-     * @summary Delete a viewer
-     * @param {string} streamId Stream id
-     * @param {string} viewerId Viewer id
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof ViewersApi
-     */
-    public deleteViewer(streamId: string, viewerId: string, options?: RawAxiosRequestConfig) {
-        return ViewersApiFp(this.configuration).deleteViewer(streamId, viewerId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Delete a viewer from a stream and revoke its token.
+   * @summary Delete a viewer
+   * @param {string} streamId Stream id
+   * @param {string} viewerId Viewer id
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof ViewersApi
+   */
+  public deleteViewer(streamId: string, viewerId: string, options?: RawAxiosRequestConfig) {
+    return ViewersApiFp(this.configuration)
+      .deleteViewer(streamId, viewerId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 
-    /**
-     * Issue a fresh viewer token.
-     * @summary Create a viewer token
-     * @param {string} roomId ID of the stream.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof ViewersApi
-     */
-    public generateViewerToken(roomId: string, options?: RawAxiosRequestConfig) {
-        return ViewersApiFp(this.configuration).generateViewerToken(roomId, options).then((request) => request(this.axios, this.basePath));
-    }
+  /**
+   * Issue a fresh viewer token.
+   * @summary Create a viewer token
+   * @param {string} roomId ID of the stream.
+   * @param {*} [options] Override http request option.
+   * @throws {RequiredError}
+   * @memberof ViewersApi
+   */
+  public generateViewerToken(roomId: string, options?: RawAxiosRequestConfig) {
+    return ViewersApiFp(this.configuration)
+      .generateViewerToken(roomId, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }
-
-
-

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -101,7 +101,7 @@ export class FishjamClient {
     try {
       await this.credentialsApi.validateCredentials();
     } catch (error) {
-      if (axios.isAxiosError(error) && (error.response?.status === 401 || error.response?.status === 404)) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
         throw new InvalidFishjamCredentialsException(error);
       }
       throw mapException(error);

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -4,6 +4,7 @@ import {
   RoomsApi,
   ViewersApi,
   RoomConfig,
+  CredentialsApi,
   StreamersApi,
   PeerOptionsWebRTC,
   PeerOptionsVapi,
@@ -27,6 +28,7 @@ export class FishjamClient {
   private readonly roomApi: RoomsApi;
   private readonly viewerApi: ViewersApi;
   private readonly streamerApi: StreamersApi;
+  private readonly credentialsApi: CredentialsApi;
   private readonly fishjamConfig: FishjamConfig;
   private deprecationWarningShown: boolean = false;
 
@@ -64,6 +66,7 @@ export class FishjamClient {
     this.roomApi = new RoomsApi(undefined, fishjamUrl, client);
     this.viewerApi = new ViewersApi(undefined, fishjamUrl, client);
     this.streamerApi = new StreamersApi(undefined, fishjamUrl, client);
+    this.credentialsApi = new CredentialsApi(undefined, fishjamUrl, client);
     this.fishjamConfig = config;
   }
 
@@ -96,13 +99,10 @@ export class FishjamClient {
    */
   async checkCredentials(): Promise<void> {
     try {
-      await this.roomApi.getAllRooms();
+      await this.credentialsApi.validateCredentials();
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        const status = error.response?.status;
-        if (status === 401 || status === 404) {
-          throw new InvalidFishjamCredentialsException(error);
-        }
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        throw new InvalidFishjamCredentialsException(error);
       }
       throw mapException(error);
     }

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -101,7 +101,7 @@ export class FishjamClient {
     try {
       await this.credentialsApi.validateCredentials();
     } catch (error) {
-      if (axios.isAxiosError(error) && error.response?.status === 404) {
+      if (axios.isAxiosError(error) && (error.response?.status === 401 || error.response?.status === 404)) {
         throw new InvalidFishjamCredentialsException(error);
       }
       throw mapException(error);

--- a/packages/js-server-sdk/src/client.ts
+++ b/packages/js-server-sdk/src/client.ts
@@ -13,7 +13,6 @@ import {
 } from '@fishjam-cloud/fishjam-openapi';
 import type { AgentCallbacks, FishjamConfig, PeerId, Room, RoomId, Peer } from './types';
 import { mapException } from './exceptions/mapper';
-import { InvalidFishjamCredentialsException } from './exceptions';
 import { getFishjamUrl } from './utils';
 import { FishjamAgent, TrackId } from './agent';
 import packageJson from '../package.json';
@@ -101,9 +100,6 @@ export class FishjamClient {
     try {
       await this.credentialsApi.validateCredentials();
     } catch (error) {
-      if (axios.isAxiosError(error) && error.response?.status === 404) {
-        throw new InvalidFishjamCredentialsException(error);
-      }
       throw mapException(error);
     }
   }

--- a/packages/js-server-sdk/src/exceptions/index.ts
+++ b/packages/js-server-sdk/src/exceptions/index.ts
@@ -34,4 +34,6 @@ export class PeerNotFoundException extends FishjamBaseException {}
 
 export class ServiceUnavailableException extends FishjamBaseException {}
 
+export class QuotaExceededException extends FishjamBaseException {}
+
 export class UnknownException extends FishjamBaseException {}

--- a/packages/js-server-sdk/src/exceptions/mapper.ts
+++ b/packages/js-server-sdk/src/exceptions/mapper.ts
@@ -2,7 +2,9 @@ import type { AxiosError as BaseAxiosError } from 'axios';
 import {
   BadRequestException,
   FishjamNotFoundException,
+  InvalidFishjamCredentialsException,
   PeerNotFoundException,
+  QuotaExceededException,
   RoomNotFoundException,
   ServiceUnavailableException,
   UnauthorizedException,
@@ -18,9 +20,15 @@ export const mapException = (error: unknown, entity?: 'peer' | 'room') => {
     switch (error.response?.status) {
       case 400:
         return new BadRequestException(error);
+      case 402:
+        return new QuotaExceededException(error);
       case 401:
         throw new UnauthorizedException(error);
       case 404:
+        if (error.request.path.includes('validate')) {
+          return new InvalidFishjamCredentialsException(error);
+        }
+
         switch (entity) {
           case 'peer':
             return new PeerNotFoundException(error);

--- a/packages/js-server-sdk/tests/config-validation.test.ts
+++ b/packages/js-server-sdk/tests/config-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { RoomsApi } from '@fishjam-cloud/fishjam-openapi';
+import { CredentialsApi } from '@fishjam-cloud/fishjam-openapi';
 import { FishjamClient } from '../src/client';
 import { InvalidFishjamCredentialsException, MissingFishjamIdException } from '../src/exceptions';
 import type { FishjamConfig } from '../src/types';
@@ -24,54 +24,54 @@ describe('FishjamClient constructor sync validation', () => {
 });
 
 describe('FishjamClient live credential checks (mocked)', () => {
-  const spy = () => vi.spyOn(RoomsApi.prototype, 'getAllRooms');
-  let getAllRoomsSpy: ReturnType<typeof spy>;
+  const spy = () => vi.spyOn(CredentialsApi.prototype, 'validateCredentials');
+  let validateSpy: ReturnType<typeof spy>;
 
   beforeEach(() => {
-    getAllRoomsSpy = spy();
+    validateSpy = spy();
   });
 
   afterEach(() => {
-    getAllRoomsSpy.mockRestore();
+    validateSpy.mockRestore();
   });
 
   it('FishjamClient.create rejects with InvalidFishjamCredentialsException on 401', async () => {
-    getAllRoomsSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
+    validateSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
 
     await expect(FishjamClient.create(VALID_CONFIG)).rejects.toThrow(InvalidFishjamCredentialsException);
   });
 
   it('FishjamClient.create rejects with InvalidFishjamCredentialsException on 404', async () => {
-    getAllRoomsSpy.mockRejectedValueOnce(axiosError(404, 'Fishjam not found'));
+    validateSpy.mockRejectedValueOnce(axiosError(404, 'Fishjam not found'));
 
     await expect(FishjamClient.create(VALID_CONFIG)).rejects.toThrow(InvalidFishjamCredentialsException);
   });
 
   it('FishjamClient.create resolves and pings backend once on success', async () => {
-    getAllRoomsSpy.mockResolvedValueOnce({ data: { data: [] } } as never);
+    validateSpy.mockResolvedValueOnce({ data: {} } as never);
 
     const client = await FishjamClient.create(VALID_CONFIG);
 
     expect(client).toBeInstanceOf(FishjamClient);
-    expect(getAllRoomsSpy).toHaveBeenCalledTimes(1);
+    expect(validateSpy).toHaveBeenCalledTimes(1);
   });
 
   it('checkCredentials throws InvalidFishjamCredentialsException on 401', async () => {
-    getAllRoomsSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
+    validateSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
 
     const client = new FishjamClient(VALID_CONFIG);
     await expect(client.checkCredentials()).rejects.toThrow(InvalidFishjamCredentialsException);
   });
 
   it('checkCredentials throws InvalidFishjamCredentialsException on 404', async () => {
-    getAllRoomsSpy.mockRejectedValueOnce(axiosError(404, 'Fishjam not found'));
+    validateSpy.mockRejectedValueOnce(axiosError(404, 'Fishjam not found'));
 
     const client = new FishjamClient(VALID_CONFIG);
     await expect(client.checkCredentials()).rejects.toThrow(InvalidFishjamCredentialsException);
   });
 
   it('checkCredentials resolves on success', async () => {
-    getAllRoomsSpy.mockResolvedValueOnce({ data: { data: [] } } as never);
+    validateSpy.mockResolvedValueOnce({ data: {} } as never);
 
     const client = new FishjamClient(VALID_CONFIG);
     await expect(client.checkCredentials()).resolves.toBeUndefined();

--- a/packages/js-server-sdk/tests/config-validation.test.ts
+++ b/packages/js-server-sdk/tests/config-validation.test.ts
@@ -8,6 +8,7 @@ const VALID_CONFIG: FishjamConfig = { fishjamId: 'fjm_test', managementToken: 't
 
 const axiosError = (status: number, detail = 'error') => ({
   isAxiosError: true,
+  request: { path: 'https://fish.jam/api/v1/connect/fishjam_id/validate' },
   message: `Request failed with status code ${status}`,
   code: 'ERR_BAD_REQUEST',
   response: { status, data: { detail } },
@@ -35,12 +36,6 @@ describe('FishjamClient live credential checks (mocked)', () => {
     validateSpy.mockRestore();
   });
 
-  it('FishjamClient.create rejects with InvalidFishjamCredentialsException on 401', async () => {
-    validateSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
-
-    await expect(FishjamClient.create(VALID_CONFIG)).rejects.toThrow(InvalidFishjamCredentialsException);
-  });
-
   it('FishjamClient.create rejects with InvalidFishjamCredentialsException on 404', async () => {
     validateSpy.mockRejectedValueOnce(axiosError(404, 'Fishjam not found'));
 
@@ -54,13 +49,6 @@ describe('FishjamClient live credential checks (mocked)', () => {
 
     expect(client).toBeInstanceOf(FishjamClient);
     expect(validateSpy).toHaveBeenCalledTimes(1);
-  });
-
-  it('checkCredentials throws InvalidFishjamCredentialsException on 401', async () => {
-    validateSpy.mockRejectedValueOnce(axiosError(401, 'Invalid token'));
-
-    const client = new FishjamClient(VALID_CONFIG);
-    await expect(client.checkCredentials()).rejects.toThrow(InvalidFishjamCredentialsException);
   });
 
   it('checkCredentials throws InvalidFishjamCredentialsException on 404', async () => {


### PR DESCRIPTION
## Description

Uses credentials validate api instead of retrieving rooms.

## Motivation and Context

Use a lightweight endpoint for validating credentials.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
