### PR TITLE
Add wh notification decoding

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -33,5 +33,5 @@ jobs:
       - name: Run integration tests
         run: yarn workspace @fishjam-cloud/js-server-sdk test
         env:
-          FISHJAM_ID: ${{ secrets.CI_FISHJAM_ID }}
+          FISHJAM_ID: ${{ vars.CI_FISHJAM_ID }}
           FISHJAM_MANAGEMENT_TOKEN: ${{ secrets.CI_FISHJAM_MANAGEMENT_TOKEN }}

--- a/examples/room-manager/src/index.ts
+++ b/examples/room-manager/src/index.ts
@@ -3,7 +3,7 @@ import cors from '@fastify/cors';
 import fastifyEnv from '@fastify/env';
 import fastifySwagger from '@fastify/swagger';
 import healthcheck from 'fastify-healthcheck';
-import { ServerMessage } from '@fishjam-cloud/js-server-sdk';
+import { decodeServerNotifications } from '@fishjam-cloud/js-server-sdk';
 
 import { configSchema } from './config';
 import { rooms } from './routes';
@@ -31,11 +31,14 @@ async function setupServer() {
 
   fastify.log.info({ config: fastify.config });
 
+  // Decode webhook bodies into typed notifications. `decodeServerNotifications`
+  // transparently unwraps a NotificationBatch, so rooms created with
+  // `batchWebhookNotifications: true` are handled the same as single notifications.
   fastify.addContentTypeParser(
     'application/x-protobuf',
     { parseAs: 'buffer' },
     async (_req: FastifyRequest, body: Buffer) => {
-      return ServerMessage.decode(body);
+      return decodeServerNotifications(body);
     }
   );
 

--- a/packages/js-server-sdk/src/index.ts
+++ b/packages/js-server-sdk/src/index.ts
@@ -20,8 +20,10 @@ export {
 
 export { ServerMessage } from '@fishjam-cloud/fishjam-proto';
 export { FishjamWSNotifier } from './ws_notifier';
+export { decodeServerNotifications } from './webhook';
 export type {
   Track,
+  ServerNotification,
   ExpectedEvents,
   IgnoredEvents,
   RoomCreated,

--- a/packages/js-server-sdk/src/notifications.ts
+++ b/packages/js-server-sdk/src/notifications.ts
@@ -68,7 +68,8 @@ export const ignoredEventsList = [
   'trackForwarding',
   'trackForwardingRemoved',
   'vadNotification',
-  // Webhook-only transport wrapper; the WebSocket notifier never receives it.
+  // Transport wrapper, not a user-facing event: unwrapped by `extractNotifications`
+  // into its constituent notifications rather than emitted under its own key.
   'notificationBatch',
   // Deprecated
   'streamConnected',
@@ -168,3 +169,48 @@ export const mapNotification = (event: ExpectedEvents, msg: unknown): unknown =>
 };
 
 export type NotificationEvents = { [K in ExpectedEvents]: (message: Notifications[K]) => void };
+
+/**
+ * A single decoded, mapped server notification tagged with its event type.
+ * The discriminated `type` lets consumers narrow `notification` to the matching
+ * payload (e.g. `if (n.type === 'peerConnected') n.notification.peerType`).
+ */
+export type ServerNotification = {
+  [K in ExpectedEvents]: { type: K; notification: Notifications[K] };
+}[ExpectedEvents];
+
+const isExpectedEvent = (event: string): event is ExpectedEvents =>
+  (expectedEventsList as readonly string[]).includes(event);
+
+/**
+ * Unwrap a {@link ServerMessage} into the individual notification messages it carries.
+ * A `notificationBatch` expands to its elements; any other message yields itself.
+ * Only one level is unwrapped — nested batches are a documented protocol violation
+ * and their inner batch (not an expected event) is dropped by {@link toServerNotification}.
+ */
+const flattenServerMessage = (message: ServerMessage): ServerMessage[] =>
+  message.notificationBatch?.notifications ?? [message];
+
+/**
+ * Map a single decoded {@link ServerMessage} to a typed notification, or `null` when
+ * its populated oneof variant is not surfaced to users (handshake, deprecated, batch).
+ */
+const toServerNotification = (message: ServerMessage): ServerNotification | null => {
+  const entry = Object.entries(message).find(([, value]) => value);
+  if (!entry) return null;
+
+  const [event, msg] = entry;
+  if (!isExpectedEvent(event)) return null;
+
+  return { type: event, notification: mapNotification(event, msg) } as ServerNotification;
+};
+
+/**
+ * Decode-side core shared by the WebSocket notifier and the webhook decoder: flatten a
+ * {@link ServerMessage} (unwrapping a batch) and map each element to a typed notification,
+ * preserving wire order and discarding non-surfaced variants.
+ */
+export const extractNotifications = (message: ServerMessage): ServerNotification[] =>
+  flattenServerMessage(message)
+    .map(toServerNotification)
+    .filter((notification): notification is ServerNotification => notification !== null);

--- a/packages/js-server-sdk/src/webhook.ts
+++ b/packages/js-server-sdk/src/webhook.ts
@@ -1,0 +1,27 @@
+import { ServerMessage } from '@fishjam-cloud/fishjam-proto';
+import { extractNotifications, ServerNotification } from './notifications';
+
+/**
+ * Decode a raw Fishjam webhook body (`application/x-protobuf`) into typed,
+ * mapped notifications.
+ *
+ * A room/stream created with `batchWebhookNotifications: true` may deliver
+ * several notifications coalesced into a single `NotificationBatch`; this helper
+ * transparently unwraps that batch, so a single message and a batch are handled
+ * the same way. Notifications are returned in wire order, with the same payload
+ * mapping the {@link FishjamWSNotifier} applies (branded ids, `peerType`/`track`
+ * enums). Non-surfaced variants (handshake, deprecated) are omitted.
+ *
+ * Accepts a Node `Buffer` (a `Uint8Array` subclass), a `Uint8Array`, or an
+ * `ArrayBuffer`.
+ *
+ * @example
+ * ```ts
+ * for (const { type, notification } of decodeServerNotifications(body)) {
+ *   if (type === 'peerConnected') handlePeerConnected(notification);
+ * }
+ * ```
+ * @category Notifications
+ */
+export const decodeServerNotifications = (data: Uint8Array | ArrayBuffer): ServerNotification[] =>
+  extractNotifications(ServerMessage.decode(data instanceof Uint8Array ? data : new Uint8Array(data)));

--- a/packages/js-server-sdk/src/ws_notifier.ts
+++ b/packages/js-server-sdk/src/ws_notifier.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events';
 import { CloseEventHandler, ErrorEventHandler, FishjamConfig } from './types';
 import { getFishjamUrl, httpToWebsocket } from './utils';
 import { ServerMessage, ServerMessage_EventType } from '@fishjam-cloud/fishjam-proto';
-import { ExpectedEvents, NotificationEvents, expectedEventsList, mapNotification } from './notifications';
+import { ExpectedEvents, NotificationEvents, extractNotifications } from './notifications';
 
 /**
  * Notifier object that can be used to get notified about various events related to the Fishjam App.
@@ -30,15 +30,16 @@ export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<N
 
   private dispatchNotification(message: MessageEvent) {
     try {
-      const data = new Uint8Array(message.data);
-      const decodedMessage = ServerMessage.decode(data);
-      const [notification, msg] = Object.entries(decodedMessage).find(([_k, v]) => v)!;
+      const decodedMessage = ServerMessage.decode(new Uint8Array(message.data));
 
-      if (!this.isExpectedEvent(notification)) return;
-
-      // TS can't narrow per-event through Object.entries, so widen emit's signature at the call site.
+      // TS can't narrow per-event through the discriminated union, so widen emit's signature here.
       const emit = this.emit as (event: ExpectedEvents, message: unknown) => boolean;
-      emit(notification, mapNotification(notification, msg));
+
+      // `extractNotifications` unwraps any NotificationBatch and applies payload mapping,
+      // so a single message and a batch are emitted identically, in wire order.
+      for (const { type, notification } of extractNotifications(decodedMessage)) {
+        emit(type, notification);
+      }
     } catch (e) {
       console.error("Couldn't decode websocket server message", e, message);
     }
@@ -52,9 +53,5 @@ export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<N
 
     this.client.send(auth);
     this.client.send(subscription);
-  }
-
-  private isExpectedEvent(notification: string): notification is ExpectedEvents {
-    return expectedEventsList.includes(notification as ExpectedEvents);
   }
 }

--- a/packages/js-server-sdk/src/ws_notifier.ts
+++ b/packages/js-server-sdk/src/ws_notifier.ts
@@ -32,8 +32,8 @@ export class FishjamWSNotifier extends (EventEmitter as new () => TypedEmitter<N
     try {
       const decodedMessage = ServerMessage.decode(new Uint8Array(message.data));
 
-      // TS can't narrow per-event through the discriminated union, so widen emit's signature here.
-      const emit = this.emit as (event: ExpectedEvents, message: unknown) => boolean;
+      // `.bind(this)` keeps emit's receiver (a bare `this.emit` runs with `this === undefined` and throws, FCE-3373); the cast widens the per-event signature TS can't narrow through the union.
+      const emit = this.emit.bind(this) as (event: ExpectedEvents, message: unknown) => boolean;
 
       // `extractNotifications` unwraps any NotificationBatch and applies payload mapping,
       // so a single message and a batch are emitted identically, in wire order.

--- a/packages/js-server-sdk/tests/notifications.test.ts
+++ b/packages/js-server-sdk/tests/notifications.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
 import type { ServerMessage } from '@fishjam-cloud/fishjam-proto';
 import { expectedEventsList, ignoredEventsList, peerEventsWithPeerType, trackEvents } from '../src/notifications';
-import type { ExpectedEvents, IgnoredEvents, Notifications } from '../src/notifications';
+import type { ExpectedEvents, IgnoredEvents, Notifications, ServerNotification } from '../src/notifications';
 import type * as SDK from '../src';
 
 //    Compile-time completeness: every `ServerMessage` oneof must be classified
@@ -72,5 +72,9 @@ describe('notifications module', () => {
     for (const event of required) {
       expect(trackEvents.has(event)).toBe(true);
     }
+  });
+
+  it("ServerNotification's discriminant covers exactly ExpectedEvents", () => {
+    expectTypeOf<ServerNotification['type']>().toEqualTypeOf<ExpectedEvents>();
   });
 });

--- a/packages/js-server-sdk/tests/webhook.test.ts
+++ b/packages/js-server-sdk/tests/webhook.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { ServerMessage, ServerMessage_PeerType, TrackType } from '@fishjam-cloud/fishjam-proto';
+import { decodeServerNotifications } from '../src/webhook';
+
+const encode = (message: Parameters<typeof ServerMessage.encode>[0]): Uint8Array =>
+  ServerMessage.encode(message).finish();
+
+const peerConnected = {
+  peerConnected: { roomId: 'room-1', peerId: 'peer-1', peerType: ServerMessage_PeerType.PEER_TYPE_WEBRTC },
+} as const;
+
+const trackAdded = {
+  trackAdded: {
+    roomId: 'room-1',
+    peerId: 'peer-1',
+    track: { id: 'track-1', type: TrackType.TRACK_TYPE_VIDEO, metadata: '{}' },
+  },
+} as const;
+
+describe('decodeServerNotifications', () => {
+  it('decodes a single non-batch notification with payload mapping applied', () => {
+    const result = decodeServerNotifications(encode(peerConnected));
+
+    expect(result).toHaveLength(1);
+    const [notification] = result;
+    expect(notification.type).toBe('peerConnected');
+    if (notification.type !== 'peerConnected') throw new Error('unreachable');
+    // enum -> user-facing string union
+    expect(notification.notification.peerType).toBe('webrtc');
+    expect(notification.notification.roomId).toBe('room-1');
+    expect(notification.notification.peerId).toBe('peer-1');
+  });
+
+  it('maps the embedded track of a trackAdded notification', () => {
+    const [notification] = decodeServerNotifications(encode(trackAdded));
+
+    expect(notification.type).toBe('trackAdded');
+    if (notification.type !== 'trackAdded') throw new Error('unreachable');
+    expect(notification.notification.track).toEqual({ id: 'track-1', type: 'video', metadata: '{}' });
+  });
+
+  it('unwraps a NotificationBatch into its elements, preserving order', () => {
+    const batch = encode({
+      notificationBatch: {
+        notifications: [
+          { roomCreated: { roomId: 'room-1' } },
+          peerConnected,
+          { roomDeleted: { roomId: 'room-1' } },
+        ],
+      },
+    });
+
+    const result = decodeServerNotifications(batch);
+
+    expect(result.map((n) => n.type)).toEqual(['roomCreated', 'peerConnected', 'roomDeleted']);
+  });
+
+  it('drops non-surfaced variants from a batch but keeps the surfaced ones', () => {
+    const batch = encode({
+      notificationBatch: {
+        notifications: [
+          { subscribeResponse: { eventType: 0 } }, // handshake — ignored
+          peerConnected,
+          { vadNotification: { roomId: 'room-1', peerId: 'peer-1', trackId: 'track-1', status: 0 } }, // ignored
+        ],
+      },
+    });
+
+    const result = decodeServerNotifications(batch);
+
+    expect(result.map((n) => n.type)).toEqual(['peerConnected']);
+  });
+
+  it('drops a nested batch element (documented protocol violation)', () => {
+    const batch = encode({
+      notificationBatch: {
+        notifications: [peerConnected, { notificationBatch: { notifications: [trackAdded] } }],
+      },
+    });
+
+    const result = decodeServerNotifications(batch);
+
+    expect(result.map((n) => n.type)).toEqual(['peerConnected']);
+  });
+
+  it('returns an empty array for an empty / unrecognized message', () => {
+    expect(decodeServerNotifications(encode({}))).toEqual([]);
+    expect(decodeServerNotifications(encode({ subscribeResponse: { eventType: 0 } }))).toEqual([]);
+  });
+
+  it('accepts Buffer, Uint8Array, and ArrayBuffer input', () => {
+    const bytes = encode(peerConnected);
+    // Copy into a standalone ArrayBuffer (encode may return a view over a larger pooled buffer).
+    const arrayBuffer = new Uint8Array(bytes).buffer as ArrayBuffer;
+
+    expect(decodeServerNotifications(bytes)).toHaveLength(1); // Uint8Array
+    expect(decodeServerNotifications(Buffer.from(bytes))).toHaveLength(1); // Buffer (Uint8Array subclass)
+    expect(decodeServerNotifications(arrayBuffer)).toHaveLength(1); // ArrayBuffer
+  });
+});

--- a/packages/js-server-sdk/tests/webhook.test.ts
+++ b/packages/js-server-sdk/tests/webhook.test.ts
@@ -42,11 +42,7 @@ describe('decodeServerNotifications', () => {
   it('unwraps a NotificationBatch into its elements, preserving order', () => {
     const batch = encode({
       notificationBatch: {
-        notifications: [
-          { roomCreated: { roomId: 'room-1' } },
-          peerConnected,
-          { roomDeleted: { roomId: 'room-1' } },
-        ],
+        notifications: [{ roomCreated: { roomId: 'room-1' } }, peerConnected, { roomDeleted: { roomId: 'room-1' } }],
       },
     });
 

--- a/packages/js-server-sdk/tests/ws_notifier.test.ts
+++ b/packages/js-server-sdk/tests/ws_notifier.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ServerMessage, ServerMessage_PeerType } from '@fishjam-cloud/fishjam-proto';
+import { FishjamWSNotifier } from '../src/ws_notifier';
+
+const encode = (message: Parameters<typeof ServerMessage.encode>[0]): Uint8Array =>
+  ServerMessage.encode(message).finish();
+
+type MessageLike = { data: Uint8Array | ArrayBuffer };
+
+/**
+ * Minimal stand-in for the global `WebSocket`: records constructed instances and
+ * exposes the handlers the notifier assigns, so a test can drive inbound messages
+ * through `dispatchNotification` without a live server.
+ */
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+
+  binaryType = 'blob';
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  onmessage: ((event: MessageLike) => void) | null = null;
+  readonly sent: unknown[] = [];
+
+  constructor(public readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: unknown) {
+    this.sent.push(data);
+  }
+}
+
+const config = { fishjamId: 'test-id', managementToken: 'test-token' };
+const noop = () => {};
+
+const peerConnected = {
+  peerConnected: { roomId: 'room-1', peerId: 'peer-1', peerType: ServerMessage_PeerType.PEER_TYPE_WEBRTC },
+} as const;
+
+const createNotifier = () => {
+  const notifier = new FishjamWSNotifier(config, noop, noop);
+  const socket = FakeWebSocket.instances.at(-1);
+  if (!socket) throw new Error('FishjamWSNotifier did not open a WebSocket');
+  return { notifier, socket };
+};
+
+describe('FishjamWSNotifier.dispatchNotification', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // Regression for FCE-3373: `emit` used to be called detached from its EventEmitter
+  // receiver, so every notification threw on `this._events` and was swallowed by the
+  // catch as a misleading "Couldn't decode" error — no handler ever fired.
+  it('emits a decoded, mapped notification to a registered handler', () => {
+    const { notifier, socket } = createNotifier();
+    const handler = vi.fn();
+    notifier.on('peerConnected', handler);
+
+    socket.onmessage?.({ data: encode(peerConnected) });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ roomId: 'room-1', peerId: 'peer-1', peerType: 'webrtc' })
+    );
+  });
+
+  it('does not log a decode error for a valid message', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(noop);
+    const { notifier, socket } = createNotifier();
+    notifier.on('peerConnected', noop);
+
+    socket.onmessage?.({ data: encode(peerConnected) });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('unwraps a NotificationBatch, emitting each notification in wire order', () => {
+    const { notifier, socket } = createNotifier();
+    const events: string[] = [];
+    notifier.on('roomCreated', () => events.push('roomCreated'));
+    notifier.on('peerConnected', () => events.push('peerConnected'));
+    notifier.on('roomDeleted', () => events.push('roomDeleted'));
+
+    socket.onmessage?.({
+      data: encode({
+        notificationBatch: {
+          notifications: [{ roomCreated: { roomId: 'room-1' } }, peerConnected, { roomDeleted: { roomId: 'room-1' } }],
+        },
+      }),
+    });
+
+    expect(events).toEqual(['roomCreated', 'peerConnected', 'roomDeleted']);
+  });
+});

--- a/typedoc.json
+++ b/typedoc.json
@@ -8,8 +8,8 @@
   "readme": "none",
   "treatValidationWarningsAsErrors": true,
   "treatWarningsAsErrors": true,
-  "intentionallyNotExported": ["expectedEventsList", "ignoredEventsList"],
+  "intentionallyNotExported": ["expectedEventsList", "ignoredEventsList", "Notification"],
   "packageOptions": {
-    "intentionallyNotExported": ["expectedEventsList", "ignoredEventsList"]
+    "intentionallyNotExported": ["expectedEventsList", "ignoredEventsList", "Notification"]
   }
 }


### PR DESCRIPTION
## Description

Add function that decodes notifications received by webhook.

## Motivation and Context

Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
