### PR TITLE
test(js-server-sdk): cover websocket notifier behavior

### DIFF
--- a/packages/js-server-sdk/tests/ws_notifier.test.ts
+++ b/packages/js-server-sdk/tests/ws_notifier.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ServerMessage, ServerMessage_PeerType } from '@fishjam-cloud/fishjam-proto';
+import { ServerMessage, ServerMessage_EventType, ServerMessage_PeerType } from '@fishjam-cloud/fishjam-proto';
 import { FishjamWSNotifier } from '../src/ws_notifier';
 
 const encode = (message: Parameters<typeof ServerMessage.encode>[0]): Uint8Array =>
@@ -54,6 +54,54 @@ describe('FishjamWSNotifier.dispatchNotification', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it('opens the expected websocket URL and requests arraybuffer messages', () => {
+    const { socket } = createNotifier();
+
+    expect(socket.url).toBe('wss://fishjam.io/api/v1/connect/test-id/socket/server/websocket');
+    expect(socket.binaryType).toBe('arraybuffer');
+  });
+
+  it('supports full Fishjam URLs when building the websocket URL', () => {
+    const notifier = new FishjamWSNotifier(
+      { fishjamId: 'http://localhost:4000/api/v1/connect/local-id', managementToken: 'test-token' },
+      noop,
+      noop
+    );
+    const socket = FakeWebSocket.instances.at(-1);
+    if (!socket) throw new Error('FishjamWSNotifier did not open a WebSocket');
+
+    expect(notifier).toBeInstanceOf(FishjamWSNotifier);
+    expect(socket.url).toBe('ws://localhost:4000/api/v1/connect/local-id/socket/server/websocket');
+  });
+
+  it('authenticates and subscribes to server notifications when the websocket opens', () => {
+    const { socket } = createNotifier();
+
+    socket.onopen?.();
+
+    expect(socket.sent).toHaveLength(2);
+    expect(ServerMessage.decode(socket.sent[0] as Uint8Array).authRequest?.token).toBe('test-token');
+    expect(ServerMessage.decode(socket.sent[1] as Uint8Array).subscribeRequest?.eventType).toBe(
+      ServerMessage_EventType.EVENT_TYPE_SERVER_NOTIFICATION
+    );
+  });
+
+  it('forwards websocket error and close events to the configured callbacks', () => {
+    const onError = vi.fn();
+    const onClose = vi.fn();
+    const notifier = new FishjamWSNotifier(config, onError, onClose);
+    const socket = FakeWebSocket.instances.at(-1);
+    if (!socket) throw new Error('FishjamWSNotifier did not open a WebSocket');
+
+    const errorEvent = new Error('boom');
+    socket.onerror?.(errorEvent);
+    socket.onclose?.({ code: 1006, reason: 'connection lost' });
+
+    expect(notifier).toBeInstanceOf(FishjamWSNotifier);
+    expect(onError).toHaveBeenCalledWith(errorEvent);
+    expect(onClose).toHaveBeenCalledWith(1006, 'connection lost');
   });
 
   // Regression for FCE-3373: `emit` used to be called detached from its EventEmitter

--- a/packages/js-server-sdk/tests/ws_notifier.test.ts
+++ b/packages/js-server-sdk/tests/ws_notifier.test.ts
@@ -96,6 +96,7 @@ describe('FishjamWSNotifier.dispatchNotification', () => {
     if (!socket) throw new Error('FishjamWSNotifier did not open a WebSocket');
 
     const errorEvent = { type: 'error' } as unknown as Event;
+    socket.onerror?.(errorEvent);
     socket.onclose?.({ code: 1006, reason: 'connection lost' });
 
     expect(notifier).toBeInstanceOf(FishjamWSNotifier);

--- a/packages/js-server-sdk/tests/ws_notifier.test.ts
+++ b/packages/js-server-sdk/tests/ws_notifier.test.ts
@@ -95,8 +95,7 @@ describe('FishjamWSNotifier.dispatchNotification', () => {
     const socket = FakeWebSocket.instances.at(-1);
     if (!socket) throw new Error('FishjamWSNotifier did not open a WebSocket');
 
-    const errorEvent = new Error('boom');
-    socket.onerror?.(errorEvent);
+    const errorEvent = { type: 'error' } as unknown as Event;
     socket.onclose?.({ code: 1006, reason: 'connection lost' });
 
     expect(notifier).toBeInstanceOf(FishjamWSNotifier);


### PR DESCRIPTION
### Motivation
- Improve coverage for the WebSocket-based notifier in the server SDK to avoid regressions and validate runtime behavior not exercised by existing tests.
- Ensure key behaviors (URL construction, binary mode, auth/subscription on open, and forwarding of error/close events) are explicitly tested, including the regression fixed in FCE-3373 around `emit` binding.

### Description
- Add `ServerMessage_EventType` to the test imports and extend `ws_notifier.test.ts` with new tests that assert websocket URL construction and `binaryType`.
- Add a test that simulates `onopen` to verify the notifier sends an auth request and a subscription request (decoded via `ServerMessage`).
- Add a test that verifies `onerror` and `onclose` events are forwarded to the configured callbacks using a `FakeWebSocket` helper used throughout the file.
- Keep existing dispatch/decoding tests in place to cover batch unwrapping and mapped notification emission.

### Testing
- Built the proto package and ran the websocket tests with `yarn workspace @fishjam-cloud/fishjam-proto build && yarn workspace @fishjam-cloud/js-server-sdk test tests/ws_notifier.test.ts`, which passed (7 tests).
- Ran type-checking and resolved missing dependency builds by running `yarn workspace @fishjam-cloud/fishjam-openapi build && yarn workspace @fishjam-cloud/js-server-sdk typecheck`, after which type-check succeeded.
- Ran formatting checks with `yarn workspace @fishjam-cloud/js-server-sdk format:check`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a300463ed6c83238cdef1bca349cee7)