### PR TITLE
fix(release): format generated code during version bump

### DIFF
--- a/packages/fishjam-openapi/src/generated/base.ts
+++ b/packages/fishjam-openapi/src/generated/base.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Fishjam API
- * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup) 
+ * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup)
  *
  * The version of the OpenAPI document: 0.27.0
  * Contact: contact@fishjam.io
@@ -12,24 +12,23 @@
  * Do not edit the class manually.
  */
 
-
 import type { Configuration } from './configuration';
 // Some imports not used depending on template conditions
 // @ts-ignore
 import type { AxiosPromise, AxiosInstance, RawAxiosRequestConfig } from 'axios';
 import globalAxios from 'axios';
 
-export const BASE_PATH = "https://fishjam.io/api/v1/connect".replace(/\/+$/, "");
+export const BASE_PATH = 'https://fishjam.io/api/v1/connect'.replace(/\/+$/, '');
 
 /**
  *
  * @export
  */
 export const COLLECTION_FORMATS = {
-    csv: ",",
-    ssv: " ",
-    tsv: "\t",
-    pipes: "|",
+  csv: ',',
+  ssv: ' ',
+  tsv: '\t',
+  pipes: '|',
 };
 
 /**
@@ -38,8 +37,8 @@ export const COLLECTION_FORMATS = {
  * @interface RequestArgs
  */
 export interface RequestArgs {
-    url: string;
-    options: RawAxiosRequestConfig;
+  url: string;
+  options: RawAxiosRequestConfig;
 }
 
 /**
@@ -48,15 +47,19 @@ export interface RequestArgs {
  * @class BaseAPI
  */
 export class BaseAPI {
-    protected configuration: Configuration | undefined;
+  protected configuration: Configuration | undefined;
 
-    constructor(configuration?: Configuration, protected basePath: string = BASE_PATH, protected axios: AxiosInstance = globalAxios) {
-        if (configuration) {
-            this.configuration = configuration;
-            this.basePath = configuration.basePath ?? basePath;
-        }
+  constructor(
+    configuration?: Configuration,
+    protected basePath: string = BASE_PATH,
+    protected axios: AxiosInstance = globalAxios
+  ) {
+    if (configuration) {
+      this.configuration = configuration;
+      this.basePath = configuration.basePath ?? basePath;
     }
-};
+  }
+}
 
 /**
  *
@@ -65,22 +68,24 @@ export class BaseAPI {
  * @extends {Error}
  */
 export class RequiredError extends Error {
-    constructor(public field: string, msg?: string) {
-        super(msg);
-        this.name = "RequiredError"
-    }
+  constructor(
+    public field: string,
+    msg?: string
+  ) {
+    super(msg);
+    this.name = 'RequiredError';
+  }
 }
 
 interface ServerMap {
-    [key: string]: {
-        url: string,
-        description: string,
-    }[];
+  [key: string]: {
+    url: string;
+    description: string;
+  }[];
 }
 
 /**
  *
  * @export
  */
-export const operationServerMap: ServerMap = {
-}
+export const operationServerMap: ServerMap = {};

--- a/packages/fishjam-openapi/src/generated/common.ts
+++ b/packages/fishjam-openapi/src/generated/common.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Fishjam API
- * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup) 
+ * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup)
  *
  * The version of the OpenAPI document: 0.27.0
  * Contact: contact@fishjam.io
@@ -12,17 +12,16 @@
  * Do not edit the class manually.
  */
 
-
-import type { Configuration } from "./configuration";
-import type { RequestArgs } from "./base";
+import type { Configuration } from './configuration';
+import type { RequestArgs } from './base';
 import type { AxiosInstance, AxiosResponse } from 'axios';
-import { RequiredError } from "./base";
+import { RequiredError } from './base';
 
 /**
  *
  * @export
  */
-export const DUMMY_BASE_URL = 'https://example.com'
+export const DUMMY_BASE_URL = 'https://example.com';
 
 /**
  *
@@ -30,80 +29,88 @@ export const DUMMY_BASE_URL = 'https://example.com'
  * @export
  */
 export const assertParamExists = function (functionName: string, paramName: string, paramValue: unknown) {
-    if (paramValue === null || paramValue === undefined) {
-        throw new RequiredError(paramName, `Required parameter ${paramName} was null or undefined when calling ${functionName}.`);
-    }
-}
+  if (paramValue === null || paramValue === undefined) {
+    throw new RequiredError(
+      paramName,
+      `Required parameter ${paramName} was null or undefined when calling ${functionName}.`
+    );
+  }
+};
 
 /**
  *
  * @export
  */
 export const setApiKeyToObject = async function (object: any, keyParamName: string, configuration?: Configuration) {
-    if (configuration && configuration.apiKey) {
-        const localVarApiKeyValue = typeof configuration.apiKey === 'function'
-            ? await configuration.apiKey(keyParamName)
-            : await configuration.apiKey;
-        object[keyParamName] = localVarApiKeyValue;
-    }
-}
+  if (configuration && configuration.apiKey) {
+    const localVarApiKeyValue =
+      typeof configuration.apiKey === 'function'
+        ? await configuration.apiKey(keyParamName)
+        : await configuration.apiKey;
+    object[keyParamName] = localVarApiKeyValue;
+  }
+};
 
 /**
  *
  * @export
  */
 export const setBasicAuthToObject = function (object: any, configuration?: Configuration) {
-    if (configuration && (configuration.username || configuration.password)) {
-        object["auth"] = { username: configuration.username, password: configuration.password };
-    }
-}
+  if (configuration && (configuration.username || configuration.password)) {
+    object['auth'] = { username: configuration.username, password: configuration.password };
+  }
+};
 
 /**
  *
  * @export
  */
 export const setBearerAuthToObject = async function (object: any, configuration?: Configuration) {
-    if (configuration && configuration.accessToken) {
-        const accessToken = typeof configuration.accessToken === 'function'
-            ? await configuration.accessToken()
-            : await configuration.accessToken;
-        object["Authorization"] = "Bearer " + accessToken;
-    }
-}
+  if (configuration && configuration.accessToken) {
+    const accessToken =
+      typeof configuration.accessToken === 'function'
+        ? await configuration.accessToken()
+        : await configuration.accessToken;
+    object['Authorization'] = 'Bearer ' + accessToken;
+  }
+};
 
 /**
  *
  * @export
  */
-export const setOAuthToObject = async function (object: any, name: string, scopes: string[], configuration?: Configuration) {
-    if (configuration && configuration.accessToken) {
-        const localVarAccessTokenValue = typeof configuration.accessToken === 'function'
-            ? await configuration.accessToken(name, scopes)
-            : await configuration.accessToken;
-        object["Authorization"] = "Bearer " + localVarAccessTokenValue;
-    }
-}
+export const setOAuthToObject = async function (
+  object: any,
+  name: string,
+  scopes: string[],
+  configuration?: Configuration
+) {
+  if (configuration && configuration.accessToken) {
+    const localVarAccessTokenValue =
+      typeof configuration.accessToken === 'function'
+        ? await configuration.accessToken(name, scopes)
+        : await configuration.accessToken;
+    object['Authorization'] = 'Bearer ' + localVarAccessTokenValue;
+  }
+};
 
-function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ""): void {
-    if (parameter == null) return;
-    if (typeof parameter === "object") {
-        if (Array.isArray(parameter)) {
-            (parameter as any[]).forEach(item => setFlattenedQueryParams(urlSearchParams, item, key));
-        } 
-        else {
-            Object.keys(parameter).forEach(currentKey => 
-                setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
-            );
-        }
-    } 
-    else {
-        if (urlSearchParams.has(key)) {
-            urlSearchParams.append(key, parameter);
-        } 
-        else {
-            urlSearchParams.set(key, parameter);
-        }
+function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: any, key: string = ''): void {
+  if (parameter == null) return;
+  if (typeof parameter === 'object') {
+    if (Array.isArray(parameter)) {
+      (parameter as any[]).forEach((item) => setFlattenedQueryParams(urlSearchParams, item, key));
+    } else {
+      Object.keys(parameter).forEach((currentKey) =>
+        setFlattenedQueryParams(urlSearchParams, parameter[currentKey], `${key}${key !== '' ? '.' : ''}${currentKey}`)
+      );
     }
+  } else {
+    if (urlSearchParams.has(key)) {
+      urlSearchParams.append(key, parameter);
+    } else {
+      urlSearchParams.set(key, parameter);
+    }
+  }
 }
 
 /**
@@ -111,40 +118,47 @@ function setFlattenedQueryParams(urlSearchParams: URLSearchParams, parameter: an
  * @export
  */
 export const setSearchParams = function (url: URL, ...objects: any[]) {
-    const searchParams = new URLSearchParams(url.search);
-    setFlattenedQueryParams(searchParams, objects);
-    url.search = searchParams.toString();
-}
+  const searchParams = new URLSearchParams(url.search);
+  setFlattenedQueryParams(searchParams, objects);
+  url.search = searchParams.toString();
+};
 
 /**
  *
  * @export
  */
 export const serializeDataIfNeeded = function (value: any, requestOptions: any, configuration?: Configuration) {
-    const nonString = typeof value !== 'string';
-    const needsSerialization = nonString && configuration && configuration.isJsonMime
-        ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
-        : nonString;
-    return needsSerialization
-        ? JSON.stringify(value !== undefined ? value : {})
-        : (value || "");
-}
+  const nonString = typeof value !== 'string';
+  const needsSerialization =
+    nonString && configuration && configuration.isJsonMime
+      ? configuration.isJsonMime(requestOptions.headers['Content-Type'])
+      : nonString;
+  return needsSerialization ? JSON.stringify(value !== undefined ? value : {}) : value || '';
+};
 
 /**
  *
  * @export
  */
 export const toPathString = function (url: URL) {
-    return url.pathname + url.search + url.hash
-}
+  return url.pathname + url.search + url.hash;
+};
 
 /**
  *
  * @export
  */
-export const createRequestFunction = function (axiosArgs: RequestArgs, globalAxios: AxiosInstance, BASE_PATH: string, configuration?: Configuration) {
-    return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-        const axiosRequestArgs = {...axiosArgs.options, url: (axios.defaults.baseURL ? '' : configuration?.basePath ?? basePath) + axiosArgs.url};
-        return axios.request<T, R>(axiosRequestArgs);
+export const createRequestFunction = function (
+  axiosArgs: RequestArgs,
+  globalAxios: AxiosInstance,
+  BASE_PATH: string,
+  configuration?: Configuration
+) {
+  return <T = unknown, R = AxiosResponse<T>>(axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+    const axiosRequestArgs = {
+      ...axiosArgs.options,
+      url: (axios.defaults.baseURL ? '' : (configuration?.basePath ?? basePath)) + axiosArgs.url,
     };
-}
+    return axios.request<T, R>(axiosRequestArgs);
+  };
+};

--- a/packages/fishjam-openapi/src/generated/configuration.ts
+++ b/packages/fishjam-openapi/src/generated/configuration.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Fishjam API
- * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup) 
+ * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup)
  *
  * The version of the OpenAPI document: 0.27.0
  * Contact: contact@fishjam.io
@@ -12,99 +12,106 @@
  * Do not edit the class manually.
  */
 
-
 export interface ConfigurationParameters {
-    apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
-    username?: string;
-    password?: string;
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
-    basePath?: string;
-    serverIndex?: number;
-    baseOptions?: any;
-    formDataCtor?: new () => any;
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+  username?: string;
+  password?: string;
+  accessToken?:
+    | string
+    | Promise<string>
+    | ((name?: string, scopes?: string[]) => string)
+    | ((name?: string, scopes?: string[]) => Promise<string>);
+  basePath?: string;
+  serverIndex?: number;
+  baseOptions?: any;
+  formDataCtor?: new () => any;
 }
 
 export class Configuration {
-    /**
-     * parameter for apiKey security
-     * @param name security name
-     * @memberof Configuration
-     */
-    apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
-    /**
-     * parameter for basic security
-     *
-     * @type {string}
-     * @memberof Configuration
-     */
-    username?: string;
-    /**
-     * parameter for basic security
-     *
-     * @type {string}
-     * @memberof Configuration
-     */
-    password?: string;
-    /**
-     * parameter for oauth2 security
-     * @param name security name
-     * @param scopes oauth2 scope
-     * @memberof Configuration
-     */
-    accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string) | ((name?: string, scopes?: string[]) => Promise<string>);
-    /**
-     * override base path
-     *
-     * @type {string}
-     * @memberof Configuration
-     */
-    basePath?: string;
-    /**
-     * override server index
-     *
-     * @type {number}
-     * @memberof Configuration
-     */
-    serverIndex?: number;
-    /**
-     * base options for axios calls
-     *
-     * @type {any}
-     * @memberof Configuration
-     */
-    baseOptions?: any;
-    /**
-     * The FormData constructor that will be used to create multipart form data
-     * requests. You can inject this here so that execution environments that
-     * do not support the FormData class can still run the generated client.
-     *
-     * @type {new () => FormData}
-     */
-    formDataCtor?: new () => any;
+  /**
+   * parameter for apiKey security
+   * @param name security name
+   * @memberof Configuration
+   */
+  apiKey?: string | Promise<string> | ((name: string) => string) | ((name: string) => Promise<string>);
+  /**
+   * parameter for basic security
+   *
+   * @type {string}
+   * @memberof Configuration
+   */
+  username?: string;
+  /**
+   * parameter for basic security
+   *
+   * @type {string}
+   * @memberof Configuration
+   */
+  password?: string;
+  /**
+   * parameter for oauth2 security
+   * @param name security name
+   * @param scopes oauth2 scope
+   * @memberof Configuration
+   */
+  accessToken?:
+    | string
+    | Promise<string>
+    | ((name?: string, scopes?: string[]) => string)
+    | ((name?: string, scopes?: string[]) => Promise<string>);
+  /**
+   * override base path
+   *
+   * @type {string}
+   * @memberof Configuration
+   */
+  basePath?: string;
+  /**
+   * override server index
+   *
+   * @type {number}
+   * @memberof Configuration
+   */
+  serverIndex?: number;
+  /**
+   * base options for axios calls
+   *
+   * @type {any}
+   * @memberof Configuration
+   */
+  baseOptions?: any;
+  /**
+   * The FormData constructor that will be used to create multipart form data
+   * requests. You can inject this here so that execution environments that
+   * do not support the FormData class can still run the generated client.
+   *
+   * @type {new () => FormData}
+   */
+  formDataCtor?: new () => any;
 
-    constructor(param: ConfigurationParameters = {}) {
-        this.apiKey = param.apiKey;
-        this.username = param.username;
-        this.password = param.password;
-        this.accessToken = param.accessToken;
-        this.basePath = param.basePath;
-        this.serverIndex = param.serverIndex;
-        this.baseOptions = param.baseOptions;
-        this.formDataCtor = param.formDataCtor;
-    }
+  constructor(param: ConfigurationParameters = {}) {
+    this.apiKey = param.apiKey;
+    this.username = param.username;
+    this.password = param.password;
+    this.accessToken = param.accessToken;
+    this.basePath = param.basePath;
+    this.serverIndex = param.serverIndex;
+    this.baseOptions = param.baseOptions;
+    this.formDataCtor = param.formDataCtor;
+  }
 
-    /**
-     * Check if the given MIME is a JSON MIME.
-     * JSON MIME examples:
-     *   application/json
-     *   application/json; charset=UTF8
-     *   APPLICATION/JSON
-     *   application/vnd.company+json
-     * @param mime - MIME (Multipurpose Internet Mail Extensions)
-     * @return True if the given MIME is JSON, false otherwise.
-     */
-    public isJsonMime(mime: string): boolean {
-        const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
-        return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
-    }
+  /**
+   * Check if the given MIME is a JSON MIME.
+   * JSON MIME examples:
+   *   application/json
+   *   application/json; charset=UTF8
+   *   APPLICATION/JSON
+   *   application/vnd.company+json
+   * @param mime - MIME (Multipurpose Internet Mail Extensions)
+   * @return True if the given MIME is JSON, false otherwise.
+   */
+  public isJsonMime(mime: string): boolean {
+    const jsonMime: RegExp = new RegExp('^(application\/json|[^;/ \t]+\/[^;/ \t]+[+]json)[ \t]*(;.*)?$', 'i');
+    return mime !== null && (jsonMime.test(mime) || mime.toLowerCase() === 'application/json-patch+json');
+  }
 }

--- a/packages/fishjam-openapi/src/generated/index.ts
+++ b/packages/fishjam-openapi/src/generated/index.ts
@@ -2,7 +2,7 @@
 /* eslint-disable */
 /**
  * Fishjam API
- * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup) 
+ * API for managing Fishjam real-time media resources.  ## Authentication ## Credentials (Fishjam ID, Fishjam Management Token) can be obtained at https://fishjam.io/app. All requests require HTTP Bearer authorization using the Fishjam Management Token.  ## Fishjam SDKs ## For TypeScript and Python users, we provide SDKs that simplify using this API. We recommend using them instead of manually consuming the API in these languages.  You can learn more about our SDKs in our [SDK Docs](http://fishjam.swmansion.com/docs/how-to/backend/server-setup)
  *
  * The version of the OpenAPI document: 0.27.0
  * Contact: contact@fishjam.io
@@ -12,7 +12,5 @@
  * Do not edit the class manually.
  */
 
-
-export * from "./api";
-export * from "./configuration";
-
+export * from './api';
+export * from './configuration';

--- a/packages/fishjam-proto/src/fishjam/agent_notifications.ts
+++ b/packages/fishjam-proto/src/fishjam/agent_notifications.ts
@@ -5,10 +5,10 @@
 // source: fishjam/agent_notifications.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
-import { Track, TrackEncoding, trackEncodingFromJSON, trackEncodingToJSON } from "./notifications/shared";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
+import { Track, TrackEncoding, trackEncodingFromJSON, trackEncodingToJSON } from './notifications/shared';
 
-export const protobufPackage = "fishjam";
+export const protobufPackage = 'fishjam';
 
 /** Defines any type of message passed from agent peer to Fishjam */
 export interface AgentRequest {
@@ -28,9 +28,7 @@ export interface AgentRequest_AuthRequest {
 /** Request to add a track of the specified type */
 export interface AgentRequest_AddTrack {
   /** Specification of the track to be added */
-  track:
-    | Track
-    | undefined;
+  track: Track | undefined;
   /** Parameters of the input data stream */
   codecParams: AgentRequest_AddTrack_CodecParameters | undefined;
 }
@@ -72,8 +70,7 @@ export interface AgentResponse {
 }
 
 /** Response confirming successful authentication */
-export interface AgentResponse_Authenticated {
-}
+export interface AgentResponse_Authenticated {}
 
 /** Notification containing a chunk of a track's data stream */
 export interface AgentResponse_TrackData {
@@ -227,35 +224,41 @@ export const AgentRequest: MessageFns<AgentRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<AgentRequest>, I>>(object: I): AgentRequest {
     const message = createBaseAgentRequest();
-    message.authRequest = (object.authRequest !== undefined && object.authRequest !== null)
-      ? AgentRequest_AuthRequest.fromPartial(object.authRequest)
-      : undefined;
-    message.addTrack = (object.addTrack !== undefined && object.addTrack !== null)
-      ? AgentRequest_AddTrack.fromPartial(object.addTrack)
-      : undefined;
-    message.removeTrack = (object.removeTrack !== undefined && object.removeTrack !== null)
-      ? AgentRequest_RemoveTrack.fromPartial(object.removeTrack)
-      : undefined;
-    message.trackData = (object.trackData !== undefined && object.trackData !== null)
-      ? AgentRequest_TrackData.fromPartial(object.trackData)
-      : undefined;
-    message.interruptTrack = (object.interruptTrack !== undefined && object.interruptTrack !== null)
-      ? AgentRequest_InterruptTrack.fromPartial(object.interruptTrack)
-      : undefined;
-    message.captureImage = (object.captureImage !== undefined && object.captureImage !== null)
-      ? AgentRequest_CaptureImage.fromPartial(object.captureImage)
-      : undefined;
+    message.authRequest =
+      object.authRequest !== undefined && object.authRequest !== null
+        ? AgentRequest_AuthRequest.fromPartial(object.authRequest)
+        : undefined;
+    message.addTrack =
+      object.addTrack !== undefined && object.addTrack !== null
+        ? AgentRequest_AddTrack.fromPartial(object.addTrack)
+        : undefined;
+    message.removeTrack =
+      object.removeTrack !== undefined && object.removeTrack !== null
+        ? AgentRequest_RemoveTrack.fromPartial(object.removeTrack)
+        : undefined;
+    message.trackData =
+      object.trackData !== undefined && object.trackData !== null
+        ? AgentRequest_TrackData.fromPartial(object.trackData)
+        : undefined;
+    message.interruptTrack =
+      object.interruptTrack !== undefined && object.interruptTrack !== null
+        ? AgentRequest_InterruptTrack.fromPartial(object.interruptTrack)
+        : undefined;
+    message.captureImage =
+      object.captureImage !== undefined && object.captureImage !== null
+        ? AgentRequest_CaptureImage.fromPartial(object.captureImage)
+        : undefined;
     return message;
   },
 };
 
 function createBaseAgentRequest_AuthRequest(): AgentRequest_AuthRequest {
-  return { token: "" };
+  return { token: '' };
 }
 
 export const AgentRequest_AuthRequest: MessageFns<AgentRequest_AuthRequest> = {
   encode(message: AgentRequest_AuthRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.token !== "") {
+    if (message.token !== '') {
       writer.uint32(10).string(message.token);
     }
     return writer;
@@ -286,12 +289,12 @@ export const AgentRequest_AuthRequest: MessageFns<AgentRequest_AuthRequest> = {
   },
 
   fromJSON(object: any): AgentRequest_AuthRequest {
-    return { token: isSet(object.token) ? globalThis.String(object.token) : "" };
+    return { token: isSet(object.token) ? globalThis.String(object.token) : '' };
   },
 
   toJSON(message: AgentRequest_AuthRequest): unknown {
     const obj: any = {};
-    if (message.token !== "") {
+    if (message.token !== '') {
       obj.token = message.token;
     }
     return obj;
@@ -302,7 +305,7 @@ export const AgentRequest_AuthRequest: MessageFns<AgentRequest_AuthRequest> = {
   },
   fromPartial<I extends Exact<DeepPartial<AgentRequest_AuthRequest>, I>>(object: I): AgentRequest_AuthRequest {
     const message = createBaseAgentRequest_AuthRequest();
-    message.token = object.token ?? "";
+    message.token = object.token ?? '';
     return message;
   },
 };
@@ -379,10 +382,11 @@ export const AgentRequest_AddTrack: MessageFns<AgentRequest_AddTrack> = {
   },
   fromPartial<I extends Exact<DeepPartial<AgentRequest_AddTrack>, I>>(object: I): AgentRequest_AddTrack {
     const message = createBaseAgentRequest_AddTrack();
-    message.track = (object.track !== undefined && object.track !== null) ? Track.fromPartial(object.track) : undefined;
-    message.codecParams = (object.codecParams !== undefined && object.codecParams !== null)
-      ? AgentRequest_AddTrack_CodecParameters.fromPartial(object.codecParams)
-      : undefined;
+    message.track = object.track !== undefined && object.track !== null ? Track.fromPartial(object.track) : undefined;
+    message.codecParams =
+      object.codecParams !== undefined && object.codecParams !== null
+        ? AgentRequest_AddTrack_CodecParameters.fromPartial(object.codecParams)
+        : undefined;
     return message;
   },
 };
@@ -468,12 +472,12 @@ export const AgentRequest_AddTrack_CodecParameters: MessageFns<AgentRequest_AddT
   },
 
   create<I extends Exact<DeepPartial<AgentRequest_AddTrack_CodecParameters>, I>>(
-    base?: I,
+    base?: I
   ): AgentRequest_AddTrack_CodecParameters {
     return AgentRequest_AddTrack_CodecParameters.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<AgentRequest_AddTrack_CodecParameters>, I>>(
-    object: I,
+    object: I
   ): AgentRequest_AddTrack_CodecParameters {
     const message = createBaseAgentRequest_AddTrack_CodecParameters();
     message.encoding = object.encoding ?? 0;
@@ -484,12 +488,12 @@ export const AgentRequest_AddTrack_CodecParameters: MessageFns<AgentRequest_AddT
 };
 
 function createBaseAgentRequest_RemoveTrack(): AgentRequest_RemoveTrack {
-  return { trackId: "" };
+  return { trackId: '' };
 }
 
 export const AgentRequest_RemoveTrack: MessageFns<AgentRequest_RemoveTrack> = {
   encode(message: AgentRequest_RemoveTrack, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       writer.uint32(10).string(message.trackId);
     }
     return writer;
@@ -520,12 +524,12 @@ export const AgentRequest_RemoveTrack: MessageFns<AgentRequest_RemoveTrack> = {
   },
 
   fromJSON(object: any): AgentRequest_RemoveTrack {
-    return { trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : "" };
+    return { trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : '' };
   },
 
   toJSON(message: AgentRequest_RemoveTrack): unknown {
     const obj: any = {};
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       obj.trackId = message.trackId;
     }
     return obj;
@@ -536,18 +540,18 @@ export const AgentRequest_RemoveTrack: MessageFns<AgentRequest_RemoveTrack> = {
   },
   fromPartial<I extends Exact<DeepPartial<AgentRequest_RemoveTrack>, I>>(object: I): AgentRequest_RemoveTrack {
     const message = createBaseAgentRequest_RemoveTrack();
-    message.trackId = object.trackId ?? "";
+    message.trackId = object.trackId ?? '';
     return message;
   },
 };
 
 function createBaseAgentRequest_TrackData(): AgentRequest_TrackData {
-  return { trackId: "", data: new Uint8Array(0) };
+  return { trackId: '', data: new Uint8Array(0) };
 }
 
 export const AgentRequest_TrackData: MessageFns<AgentRequest_TrackData> = {
   encode(message: AgentRequest_TrackData, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       writer.uint32(10).string(message.trackId);
     }
     if (message.data.length !== 0) {
@@ -590,14 +594,14 @@ export const AgentRequest_TrackData: MessageFns<AgentRequest_TrackData> = {
 
   fromJSON(object: any): AgentRequest_TrackData {
     return {
-      trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : "",
+      trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : '',
       data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(0),
     };
   },
 
   toJSON(message: AgentRequest_TrackData): unknown {
     const obj: any = {};
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       obj.trackId = message.trackId;
     }
     if (message.data.length !== 0) {
@@ -611,19 +615,19 @@ export const AgentRequest_TrackData: MessageFns<AgentRequest_TrackData> = {
   },
   fromPartial<I extends Exact<DeepPartial<AgentRequest_TrackData>, I>>(object: I): AgentRequest_TrackData {
     const message = createBaseAgentRequest_TrackData();
-    message.trackId = object.trackId ?? "";
+    message.trackId = object.trackId ?? '';
     message.data = object.data ?? new Uint8Array(0);
     return message;
   },
 };
 
 function createBaseAgentRequest_InterruptTrack(): AgentRequest_InterruptTrack {
-  return { trackId: "" };
+  return { trackId: '' };
 }
 
 export const AgentRequest_InterruptTrack: MessageFns<AgentRequest_InterruptTrack> = {
   encode(message: AgentRequest_InterruptTrack, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       writer.uint32(10).string(message.trackId);
     }
     return writer;
@@ -654,12 +658,12 @@ export const AgentRequest_InterruptTrack: MessageFns<AgentRequest_InterruptTrack
   },
 
   fromJSON(object: any): AgentRequest_InterruptTrack {
-    return { trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : "" };
+    return { trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : '' };
   },
 
   toJSON(message: AgentRequest_InterruptTrack): unknown {
     const obj: any = {};
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       obj.trackId = message.trackId;
     }
     return obj;
@@ -670,18 +674,18 @@ export const AgentRequest_InterruptTrack: MessageFns<AgentRequest_InterruptTrack
   },
   fromPartial<I extends Exact<DeepPartial<AgentRequest_InterruptTrack>, I>>(object: I): AgentRequest_InterruptTrack {
     const message = createBaseAgentRequest_InterruptTrack();
-    message.trackId = object.trackId ?? "";
+    message.trackId = object.trackId ?? '';
     return message;
   },
 };
 
 function createBaseAgentRequest_CaptureImage(): AgentRequest_CaptureImage {
-  return { trackId: "" };
+  return { trackId: '' };
 }
 
 export const AgentRequest_CaptureImage: MessageFns<AgentRequest_CaptureImage> = {
   encode(message: AgentRequest_CaptureImage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       writer.uint32(10).string(message.trackId);
     }
     return writer;
@@ -712,12 +716,12 @@ export const AgentRequest_CaptureImage: MessageFns<AgentRequest_CaptureImage> = 
   },
 
   fromJSON(object: any): AgentRequest_CaptureImage {
-    return { trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : "" };
+    return { trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : '' };
   },
 
   toJSON(message: AgentRequest_CaptureImage): unknown {
     const obj: any = {};
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       obj.trackId = message.trackId;
     }
     return obj;
@@ -728,7 +732,7 @@ export const AgentRequest_CaptureImage: MessageFns<AgentRequest_CaptureImage> = 
   },
   fromPartial<I extends Exact<DeepPartial<AgentRequest_CaptureImage>, I>>(object: I): AgentRequest_CaptureImage {
     const message = createBaseAgentRequest_CaptureImage();
-    message.trackId = object.trackId ?? "";
+    message.trackId = object.trackId ?? '';
     return message;
   },
 };
@@ -820,15 +824,18 @@ export const AgentResponse: MessageFns<AgentResponse> = {
   },
   fromPartial<I extends Exact<DeepPartial<AgentResponse>, I>>(object: I): AgentResponse {
     const message = createBaseAgentResponse();
-    message.authenticated = (object.authenticated !== undefined && object.authenticated !== null)
-      ? AgentResponse_Authenticated.fromPartial(object.authenticated)
-      : undefined;
-    message.trackData = (object.trackData !== undefined && object.trackData !== null)
-      ? AgentResponse_TrackData.fromPartial(object.trackData)
-      : undefined;
-    message.trackImage = (object.trackImage !== undefined && object.trackImage !== null)
-      ? AgentResponse_TrackImage.fromPartial(object.trackImage)
-      : undefined;
+    message.authenticated =
+      object.authenticated !== undefined && object.authenticated !== null
+        ? AgentResponse_Authenticated.fromPartial(object.authenticated)
+        : undefined;
+    message.trackData =
+      object.trackData !== undefined && object.trackData !== null
+        ? AgentResponse_TrackData.fromPartial(object.trackData)
+        : undefined;
+    message.trackImage =
+      object.trackImage !== undefined && object.trackImage !== null
+        ? AgentResponse_TrackImage.fromPartial(object.trackImage)
+        : undefined;
     return message;
   },
 };
@@ -877,12 +884,12 @@ export const AgentResponse_Authenticated: MessageFns<AgentResponse_Authenticated
 };
 
 function createBaseAgentResponse_TrackData(): AgentResponse_TrackData {
-  return { peerId: "", track: undefined, data: new Uint8Array(0) };
+  return { peerId: '', track: undefined, data: new Uint8Array(0) };
 }
 
 export const AgentResponse_TrackData: MessageFns<AgentResponse_TrackData> = {
   encode(message: AgentResponse_TrackData, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(10).string(message.peerId);
     }
     if (message.track !== undefined) {
@@ -936,7 +943,7 @@ export const AgentResponse_TrackData: MessageFns<AgentResponse_TrackData> = {
 
   fromJSON(object: any): AgentResponse_TrackData {
     return {
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
       track: isSet(object.track) ? Track.fromJSON(object.track) : undefined,
       data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(0),
     };
@@ -944,7 +951,7 @@ export const AgentResponse_TrackData: MessageFns<AgentResponse_TrackData> = {
 
   toJSON(message: AgentResponse_TrackData): unknown {
     const obj: any = {};
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
     if (message.track !== undefined) {
@@ -961,23 +968,23 @@ export const AgentResponse_TrackData: MessageFns<AgentResponse_TrackData> = {
   },
   fromPartial<I extends Exact<DeepPartial<AgentResponse_TrackData>, I>>(object: I): AgentResponse_TrackData {
     const message = createBaseAgentResponse_TrackData();
-    message.peerId = object.peerId ?? "";
-    message.track = (object.track !== undefined && object.track !== null) ? Track.fromPartial(object.track) : undefined;
+    message.peerId = object.peerId ?? '';
+    message.track = object.track !== undefined && object.track !== null ? Track.fromPartial(object.track) : undefined;
     message.data = object.data ?? new Uint8Array(0);
     return message;
   },
 };
 
 function createBaseAgentResponse_TrackImage(): AgentResponse_TrackImage {
-  return { trackId: "", contentType: "", data: new Uint8Array(0) };
+  return { trackId: '', contentType: '', data: new Uint8Array(0) };
 }
 
 export const AgentResponse_TrackImage: MessageFns<AgentResponse_TrackImage> = {
   encode(message: AgentResponse_TrackImage, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       writer.uint32(10).string(message.trackId);
     }
-    if (message.contentType !== "") {
+    if (message.contentType !== '') {
       writer.uint32(18).string(message.contentType);
     }
     if (message.data.length !== 0) {
@@ -1028,18 +1035,18 @@ export const AgentResponse_TrackImage: MessageFns<AgentResponse_TrackImage> = {
 
   fromJSON(object: any): AgentResponse_TrackImage {
     return {
-      trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : "",
-      contentType: isSet(object.contentType) ? globalThis.String(object.contentType) : "",
+      trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : '',
+      contentType: isSet(object.contentType) ? globalThis.String(object.contentType) : '',
       data: isSet(object.data) ? bytesFromBase64(object.data) : new Uint8Array(0),
     };
   },
 
   toJSON(message: AgentResponse_TrackImage): unknown {
     const obj: any = {};
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       obj.trackId = message.trackId;
     }
-    if (message.contentType !== "") {
+    if (message.contentType !== '') {
       obj.contentType = message.contentType;
     }
     if (message.data.length !== 0) {
@@ -1053,8 +1060,8 @@ export const AgentResponse_TrackImage: MessageFns<AgentResponse_TrackImage> = {
   },
   fromPartial<I extends Exact<DeepPartial<AgentResponse_TrackImage>, I>>(object: I): AgentResponse_TrackImage {
     const message = createBaseAgentResponse_TrackImage();
-    message.trackId = object.trackId ?? "";
-    message.contentType = object.contentType ?? "";
+    message.trackId = object.trackId ?? '';
+    message.contentType = object.contentType ?? '';
     message.data = object.data ?? new Uint8Array(0);
     return message;
   },
@@ -1062,7 +1069,7 @@ export const AgentResponse_TrackImage: MessageFns<AgentResponse_TrackImage> = {
 
 function bytesFromBase64(b64: string): Uint8Array {
   if ((globalThis as any).Buffer) {
-    return Uint8Array.from(globalThis.Buffer.from(b64, "base64"));
+    return Uint8Array.from(globalThis.Buffer.from(b64, 'base64'));
   } else {
     const bin = globalThis.atob(b64);
     const arr = new Uint8Array(bin.length);
@@ -1075,26 +1082,31 @@ function bytesFromBase64(b64: string): Uint8Array {
 
 function base64FromBytes(arr: Uint8Array): string {
   if ((globalThis as any).Buffer) {
-    return globalThis.Buffer.from(arr).toString("base64");
+    return globalThis.Buffer.from(arr).toString('base64');
   } else {
     const bin: string[] = [];
     arr.forEach((byte) => {
       bin.push(globalThis.String.fromCharCode(byte));
     });
-    return globalThis.btoa(bin.join(""));
+    return globalThis.btoa(bin.join(''));
   }
 }
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {

--- a/packages/fishjam-proto/src/fishjam/notifications/shared.ts
+++ b/packages/fishjam-proto/src/fishjam/notifications/shared.ts
@@ -5,9 +5,9 @@
 // source: fishjam/notifications/shared.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
 
-export const protobufPackage = "fishjam.notifications";
+export const protobufPackage = 'fishjam.notifications';
 
 /** Defines types of tracks being published by peers and component */
 export enum TrackType {
@@ -20,16 +20,16 @@ export enum TrackType {
 export function trackTypeFromJSON(object: any): TrackType {
   switch (object) {
     case 0:
-    case "TRACK_TYPE_UNSPECIFIED":
+    case 'TRACK_TYPE_UNSPECIFIED':
       return TrackType.TRACK_TYPE_UNSPECIFIED;
     case 1:
-    case "TRACK_TYPE_VIDEO":
+    case 'TRACK_TYPE_VIDEO':
       return TrackType.TRACK_TYPE_VIDEO;
     case 2:
-    case "TRACK_TYPE_AUDIO":
+    case 'TRACK_TYPE_AUDIO':
       return TrackType.TRACK_TYPE_AUDIO;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return TrackType.UNRECOGNIZED;
   }
@@ -38,14 +38,14 @@ export function trackTypeFromJSON(object: any): TrackType {
 export function trackTypeToJSON(object: TrackType): string {
   switch (object) {
     case TrackType.TRACK_TYPE_UNSPECIFIED:
-      return "TRACK_TYPE_UNSPECIFIED";
+      return 'TRACK_TYPE_UNSPECIFIED';
     case TrackType.TRACK_TYPE_VIDEO:
-      return "TRACK_TYPE_VIDEO";
+      return 'TRACK_TYPE_VIDEO';
     case TrackType.TRACK_TYPE_AUDIO:
-      return "TRACK_TYPE_AUDIO";
+      return 'TRACK_TYPE_AUDIO';
     case TrackType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -59,16 +59,16 @@ export enum TrackEncoding {
 export function trackEncodingFromJSON(object: any): TrackEncoding {
   switch (object) {
     case 0:
-    case "TRACK_ENCODING_UNSPECIFIED":
+    case 'TRACK_ENCODING_UNSPECIFIED':
       return TrackEncoding.TRACK_ENCODING_UNSPECIFIED;
     case 1:
-    case "TRACK_ENCODING_PCM16":
+    case 'TRACK_ENCODING_PCM16':
       return TrackEncoding.TRACK_ENCODING_PCM16;
     case 2:
-    case "TRACK_ENCODING_OPUS":
+    case 'TRACK_ENCODING_OPUS':
       return TrackEncoding.TRACK_ENCODING_OPUS;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return TrackEncoding.UNRECOGNIZED;
   }
@@ -77,14 +77,14 @@ export function trackEncodingFromJSON(object: any): TrackEncoding {
 export function trackEncodingToJSON(object: TrackEncoding): string {
   switch (object) {
     case TrackEncoding.TRACK_ENCODING_UNSPECIFIED:
-      return "TRACK_ENCODING_UNSPECIFIED";
+      return 'TRACK_ENCODING_UNSPECIFIED';
     case TrackEncoding.TRACK_ENCODING_PCM16:
-      return "TRACK_ENCODING_PCM16";
+      return 'TRACK_ENCODING_PCM16';
     case TrackEncoding.TRACK_ENCODING_OPUS:
-      return "TRACK_ENCODING_OPUS";
+      return 'TRACK_ENCODING_OPUS';
     case TrackEncoding.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -96,18 +96,18 @@ export interface Track {
 }
 
 function createBaseTrack(): Track {
-  return { id: "", type: 0, metadata: "" };
+  return { id: '', type: 0, metadata: '' };
 }
 
 export const Track: MessageFns<Track> = {
   encode(message: Track, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.id !== "") {
+    if (message.id !== '') {
       writer.uint32(10).string(message.id);
     }
     if (message.type !== 0) {
       writer.uint32(16).int32(message.type);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== '') {
       writer.uint32(26).string(message.metadata);
     }
     return writer;
@@ -155,21 +155,21 @@ export const Track: MessageFns<Track> = {
 
   fromJSON(object: any): Track {
     return {
-      id: isSet(object.id) ? globalThis.String(object.id) : "",
+      id: isSet(object.id) ? globalThis.String(object.id) : '',
       type: isSet(object.type) ? trackTypeFromJSON(object.type) : 0,
-      metadata: isSet(object.metadata) ? globalThis.String(object.metadata) : "",
+      metadata: isSet(object.metadata) ? globalThis.String(object.metadata) : '',
     };
   },
 
   toJSON(message: Track): unknown {
     const obj: any = {};
-    if (message.id !== "") {
+    if (message.id !== '') {
       obj.id = message.id;
     }
     if (message.type !== 0) {
       obj.type = trackTypeToJSON(message.type);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== '') {
       obj.metadata = message.metadata;
     }
     return obj;
@@ -180,23 +180,28 @@ export const Track: MessageFns<Track> = {
   },
   fromPartial<I extends Exact<DeepPartial<Track>, I>>(object: I): Track {
     const message = createBaseTrack();
-    message.id = object.id ?? "";
+    message.id = object.id ?? '';
     message.type = object.type ?? 0;
-    message.metadata = object.metadata ?? "";
+    message.metadata = object.metadata ?? '';
     return message;
   },
 };
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {

--- a/packages/fishjam-proto/src/fishjam/server_notifications.ts
+++ b/packages/fishjam-proto/src/fishjam/server_notifications.ts
@@ -5,10 +5,10 @@
 // source: fishjam/server_notifications.proto
 
 /* eslint-disable */
-import { BinaryReader, BinaryWriter } from "@bufbuild/protobuf/wire";
-import { Track } from "./notifications/shared";
+import { BinaryReader, BinaryWriter } from '@bufbuild/protobuf/wire';
+import { Track } from './notifications/shared';
 
-export const protobufPackage = "fishjam";
+export const protobufPackage = 'fishjam';
 
 /** Defines any type of message passed between FJ and server peer */
 export interface ServerMessage {
@@ -36,33 +36,19 @@ export interface ServerMessage {
   viewerConnected?: ServerMessage_ViewerConnected | undefined;
   viewerDisconnected?: ServerMessage_ViewerDisconnected | undefined;
   streamerConnected?: ServerMessage_StreamerConnected | undefined;
-  streamerDisconnected?:
-    | ServerMessage_StreamerDisconnected
-    | undefined;
+  streamerDisconnected?: ServerMessage_StreamerDisconnected | undefined;
   /** Batch */
-  notificationBatch?:
-    | ServerMessage_NotificationBatch
-    | undefined;
+  notificationBatch?: ServerMessage_NotificationBatch | undefined;
   /** @deprecated */
-  streamConnected?:
-    | ServerMessage_StreamConnected
-    | undefined;
+  streamConnected?: ServerMessage_StreamConnected | undefined;
   /** @deprecated */
-  streamDisconnected?:
-    | ServerMessage_StreamDisconnected
-    | undefined;
+  streamDisconnected?: ServerMessage_StreamDisconnected | undefined;
   /** @deprecated */
-  hlsPlayable?:
-    | ServerMessage_HlsPlayable
-    | undefined;
+  hlsPlayable?: ServerMessage_HlsPlayable | undefined;
   /** @deprecated */
-  hlsUploaded?:
-    | ServerMessage_HlsUploaded
-    | undefined;
+  hlsUploaded?: ServerMessage_HlsUploaded | undefined;
   /** @deprecated */
-  hlsUploadCrashed?:
-    | ServerMessage_HlsUploadCrashed
-    | undefined;
+  hlsUploadCrashed?: ServerMessage_HlsUploadCrashed | undefined;
   /** @deprecated */
   componentCrashed?: ServerMessage_ComponentCrashed | undefined;
 }
@@ -78,19 +64,19 @@ export enum ServerMessage_PeerType {
 export function serverMessage_PeerTypeFromJSON(object: any): ServerMessage_PeerType {
   switch (object) {
     case 0:
-    case "PEER_TYPE_UNSPECIFIED":
+    case 'PEER_TYPE_UNSPECIFIED':
       return ServerMessage_PeerType.PEER_TYPE_UNSPECIFIED;
     case 1:
-    case "PEER_TYPE_WEBRTC":
+    case 'PEER_TYPE_WEBRTC':
       return ServerMessage_PeerType.PEER_TYPE_WEBRTC;
     case 2:
-    case "PEER_TYPE_AGENT":
+    case 'PEER_TYPE_AGENT':
       return ServerMessage_PeerType.PEER_TYPE_AGENT;
     case 3:
-    case "PEER_TYPE_VAPI":
+    case 'PEER_TYPE_VAPI':
       return ServerMessage_PeerType.PEER_TYPE_VAPI;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return ServerMessage_PeerType.UNRECOGNIZED;
   }
@@ -99,16 +85,16 @@ export function serverMessage_PeerTypeFromJSON(object: any): ServerMessage_PeerT
 export function serverMessage_PeerTypeToJSON(object: ServerMessage_PeerType): string {
   switch (object) {
     case ServerMessage_PeerType.PEER_TYPE_UNSPECIFIED:
-      return "PEER_TYPE_UNSPECIFIED";
+      return 'PEER_TYPE_UNSPECIFIED';
     case ServerMessage_PeerType.PEER_TYPE_WEBRTC:
-      return "PEER_TYPE_WEBRTC";
+      return 'PEER_TYPE_WEBRTC';
     case ServerMessage_PeerType.PEER_TYPE_AGENT:
-      return "PEER_TYPE_AGENT";
+      return 'PEER_TYPE_AGENT';
     case ServerMessage_PeerType.PEER_TYPE_VAPI:
-      return "PEER_TYPE_VAPI";
+      return 'PEER_TYPE_VAPI';
     case ServerMessage_PeerType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -122,13 +108,13 @@ export enum ServerMessage_EventType {
 export function serverMessage_EventTypeFromJSON(object: any): ServerMessage_EventType {
   switch (object) {
     case 0:
-    case "EVENT_TYPE_UNSPECIFIED":
+    case 'EVENT_TYPE_UNSPECIFIED':
       return ServerMessage_EventType.EVENT_TYPE_UNSPECIFIED;
     case 1:
-    case "EVENT_TYPE_SERVER_NOTIFICATION":
+    case 'EVENT_TYPE_SERVER_NOTIFICATION':
       return ServerMessage_EventType.EVENT_TYPE_SERVER_NOTIFICATION;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return ServerMessage_EventType.UNRECOGNIZED;
   }
@@ -137,12 +123,12 @@ export function serverMessage_EventTypeFromJSON(object: any): ServerMessage_Even
 export function serverMessage_EventTypeToJSON(object: ServerMessage_EventType): string {
   switch (object) {
     case ServerMessage_EventType.EVENT_TYPE_UNSPECIFIED:
-      return "EVENT_TYPE_UNSPECIFIED";
+      return 'EVENT_TYPE_UNSPECIFIED';
     case ServerMessage_EventType.EVENT_TYPE_SERVER_NOTIFICATION:
-      return "EVENT_TYPE_SERVER_NOTIFICATION";
+      return 'EVENT_TYPE_SERVER_NOTIFICATION';
     case ServerMessage_EventType.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -194,8 +180,7 @@ export interface ServerMessage_ComponentCrashed {
 }
 
 /** Response sent by FJ, confirming successfull authentication */
-export interface ServerMessage_Authenticated {
-}
+export interface ServerMessage_Authenticated {}
 
 /** Request sent by peer, to authenticate to FJ server */
 export interface ServerMessage_AuthRequest {
@@ -323,16 +308,16 @@ export enum ServerMessage_VadNotification_Status {
 export function serverMessage_VadNotification_StatusFromJSON(object: any): ServerMessage_VadNotification_Status {
   switch (object) {
     case 0:
-    case "STATUS_UNSPECIFIED":
+    case 'STATUS_UNSPECIFIED':
       return ServerMessage_VadNotification_Status.STATUS_UNSPECIFIED;
     case 1:
-    case "STATUS_SILENCE":
+    case 'STATUS_SILENCE':
       return ServerMessage_VadNotification_Status.STATUS_SILENCE;
     case 2:
-    case "STATUS_SPEECH":
+    case 'STATUS_SPEECH':
       return ServerMessage_VadNotification_Status.STATUS_SPEECH;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return ServerMessage_VadNotification_Status.UNRECOGNIZED;
   }
@@ -341,14 +326,14 @@ export function serverMessage_VadNotification_StatusFromJSON(object: any): Serve
 export function serverMessage_VadNotification_StatusToJSON(object: ServerMessage_VadNotification_Status): string {
   switch (object) {
     case ServerMessage_VadNotification_Status.STATUS_UNSPECIFIED:
-      return "STATUS_UNSPECIFIED";
+      return 'STATUS_UNSPECIFIED';
     case ServerMessage_VadNotification_Status.STATUS_SILENCE:
-      return "STATUS_SILENCE";
+      return 'STATUS_SILENCE';
     case ServerMessage_VadNotification_Status.STATUS_SPEECH:
-      return "STATUS_SPEECH";
+      return 'STATUS_SPEECH';
     case ServerMessage_VadNotification_Status.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -994,114 +979,145 @@ export const ServerMessage: MessageFns<ServerMessage> = {
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage>, I>>(object: I): ServerMessage {
     const message = createBaseServerMessage();
-    message.authenticated = (object.authenticated !== undefined && object.authenticated !== null)
-      ? ServerMessage_Authenticated.fromPartial(object.authenticated)
-      : undefined;
-    message.authRequest = (object.authRequest !== undefined && object.authRequest !== null)
-      ? ServerMessage_AuthRequest.fromPartial(object.authRequest)
-      : undefined;
-    message.subscribeRequest = (object.subscribeRequest !== undefined && object.subscribeRequest !== null)
-      ? ServerMessage_SubscribeRequest.fromPartial(object.subscribeRequest)
-      : undefined;
-    message.subscribeResponse = (object.subscribeResponse !== undefined && object.subscribeResponse !== null)
-      ? ServerMessage_SubscribeResponse.fromPartial(object.subscribeResponse)
-      : undefined;
-    message.roomCreated = (object.roomCreated !== undefined && object.roomCreated !== null)
-      ? ServerMessage_RoomCreated.fromPartial(object.roomCreated)
-      : undefined;
-    message.roomDeleted = (object.roomDeleted !== undefined && object.roomDeleted !== null)
-      ? ServerMessage_RoomDeleted.fromPartial(object.roomDeleted)
-      : undefined;
-    message.roomCrashed = (object.roomCrashed !== undefined && object.roomCrashed !== null)
-      ? ServerMessage_RoomCrashed.fromPartial(object.roomCrashed)
-      : undefined;
-    message.peerConnected = (object.peerConnected !== undefined && object.peerConnected !== null)
-      ? ServerMessage_PeerConnected.fromPartial(object.peerConnected)
-      : undefined;
-    message.peerDisconnected = (object.peerDisconnected !== undefined && object.peerDisconnected !== null)
-      ? ServerMessage_PeerDisconnected.fromPartial(object.peerDisconnected)
-      : undefined;
-    message.peerCrashed = (object.peerCrashed !== undefined && object.peerCrashed !== null)
-      ? ServerMessage_PeerCrashed.fromPartial(object.peerCrashed)
-      : undefined;
-    message.peerMetadataUpdated = (object.peerMetadataUpdated !== undefined && object.peerMetadataUpdated !== null)
-      ? ServerMessage_PeerMetadataUpdated.fromPartial(object.peerMetadataUpdated)
-      : undefined;
-    message.trackAdded = (object.trackAdded !== undefined && object.trackAdded !== null)
-      ? ServerMessage_TrackAdded.fromPartial(object.trackAdded)
-      : undefined;
-    message.trackRemoved = (object.trackRemoved !== undefined && object.trackRemoved !== null)
-      ? ServerMessage_TrackRemoved.fromPartial(object.trackRemoved)
-      : undefined;
-    message.trackMetadataUpdated = (object.trackMetadataUpdated !== undefined && object.trackMetadataUpdated !== null)
-      ? ServerMessage_TrackMetadataUpdated.fromPartial(object.trackMetadataUpdated)
-      : undefined;
-    message.peerAdded = (object.peerAdded !== undefined && object.peerAdded !== null)
-      ? ServerMessage_PeerAdded.fromPartial(object.peerAdded)
-      : undefined;
-    message.peerDeleted = (object.peerDeleted !== undefined && object.peerDeleted !== null)
-      ? ServerMessage_PeerDeleted.fromPartial(object.peerDeleted)
-      : undefined;
-    message.channelAdded = (object.channelAdded !== undefined && object.channelAdded !== null)
-      ? ServerMessage_ChannelAdded.fromPartial(object.channelAdded)
-      : undefined;
-    message.channelRemoved = (object.channelRemoved !== undefined && object.channelRemoved !== null)
-      ? ServerMessage_ChannelRemoved.fromPartial(object.channelRemoved)
-      : undefined;
-    message.trackForwarding = (object.trackForwarding !== undefined && object.trackForwarding !== null)
-      ? ServerMessage_TrackForwarding.fromPartial(object.trackForwarding)
-      : undefined;
+    message.authenticated =
+      object.authenticated !== undefined && object.authenticated !== null
+        ? ServerMessage_Authenticated.fromPartial(object.authenticated)
+        : undefined;
+    message.authRequest =
+      object.authRequest !== undefined && object.authRequest !== null
+        ? ServerMessage_AuthRequest.fromPartial(object.authRequest)
+        : undefined;
+    message.subscribeRequest =
+      object.subscribeRequest !== undefined && object.subscribeRequest !== null
+        ? ServerMessage_SubscribeRequest.fromPartial(object.subscribeRequest)
+        : undefined;
+    message.subscribeResponse =
+      object.subscribeResponse !== undefined && object.subscribeResponse !== null
+        ? ServerMessage_SubscribeResponse.fromPartial(object.subscribeResponse)
+        : undefined;
+    message.roomCreated =
+      object.roomCreated !== undefined && object.roomCreated !== null
+        ? ServerMessage_RoomCreated.fromPartial(object.roomCreated)
+        : undefined;
+    message.roomDeleted =
+      object.roomDeleted !== undefined && object.roomDeleted !== null
+        ? ServerMessage_RoomDeleted.fromPartial(object.roomDeleted)
+        : undefined;
+    message.roomCrashed =
+      object.roomCrashed !== undefined && object.roomCrashed !== null
+        ? ServerMessage_RoomCrashed.fromPartial(object.roomCrashed)
+        : undefined;
+    message.peerConnected =
+      object.peerConnected !== undefined && object.peerConnected !== null
+        ? ServerMessage_PeerConnected.fromPartial(object.peerConnected)
+        : undefined;
+    message.peerDisconnected =
+      object.peerDisconnected !== undefined && object.peerDisconnected !== null
+        ? ServerMessage_PeerDisconnected.fromPartial(object.peerDisconnected)
+        : undefined;
+    message.peerCrashed =
+      object.peerCrashed !== undefined && object.peerCrashed !== null
+        ? ServerMessage_PeerCrashed.fromPartial(object.peerCrashed)
+        : undefined;
+    message.peerMetadataUpdated =
+      object.peerMetadataUpdated !== undefined && object.peerMetadataUpdated !== null
+        ? ServerMessage_PeerMetadataUpdated.fromPartial(object.peerMetadataUpdated)
+        : undefined;
+    message.trackAdded =
+      object.trackAdded !== undefined && object.trackAdded !== null
+        ? ServerMessage_TrackAdded.fromPartial(object.trackAdded)
+        : undefined;
+    message.trackRemoved =
+      object.trackRemoved !== undefined && object.trackRemoved !== null
+        ? ServerMessage_TrackRemoved.fromPartial(object.trackRemoved)
+        : undefined;
+    message.trackMetadataUpdated =
+      object.trackMetadataUpdated !== undefined && object.trackMetadataUpdated !== null
+        ? ServerMessage_TrackMetadataUpdated.fromPartial(object.trackMetadataUpdated)
+        : undefined;
+    message.peerAdded =
+      object.peerAdded !== undefined && object.peerAdded !== null
+        ? ServerMessage_PeerAdded.fromPartial(object.peerAdded)
+        : undefined;
+    message.peerDeleted =
+      object.peerDeleted !== undefined && object.peerDeleted !== null
+        ? ServerMessage_PeerDeleted.fromPartial(object.peerDeleted)
+        : undefined;
+    message.channelAdded =
+      object.channelAdded !== undefined && object.channelAdded !== null
+        ? ServerMessage_ChannelAdded.fromPartial(object.channelAdded)
+        : undefined;
+    message.channelRemoved =
+      object.channelRemoved !== undefined && object.channelRemoved !== null
+        ? ServerMessage_ChannelRemoved.fromPartial(object.channelRemoved)
+        : undefined;
+    message.trackForwarding =
+      object.trackForwarding !== undefined && object.trackForwarding !== null
+        ? ServerMessage_TrackForwarding.fromPartial(object.trackForwarding)
+        : undefined;
     message.trackForwardingRemoved =
-      (object.trackForwardingRemoved !== undefined && object.trackForwardingRemoved !== null)
+      object.trackForwardingRemoved !== undefined && object.trackForwardingRemoved !== null
         ? ServerMessage_TrackForwardingRemoved.fromPartial(object.trackForwardingRemoved)
         : undefined;
-    message.vadNotification = (object.vadNotification !== undefined && object.vadNotification !== null)
-      ? ServerMessage_VadNotification.fromPartial(object.vadNotification)
-      : undefined;
-    message.viewerConnected = (object.viewerConnected !== undefined && object.viewerConnected !== null)
-      ? ServerMessage_ViewerConnected.fromPartial(object.viewerConnected)
-      : undefined;
-    message.viewerDisconnected = (object.viewerDisconnected !== undefined && object.viewerDisconnected !== null)
-      ? ServerMessage_ViewerDisconnected.fromPartial(object.viewerDisconnected)
-      : undefined;
-    message.streamerConnected = (object.streamerConnected !== undefined && object.streamerConnected !== null)
-      ? ServerMessage_StreamerConnected.fromPartial(object.streamerConnected)
-      : undefined;
-    message.streamerDisconnected = (object.streamerDisconnected !== undefined && object.streamerDisconnected !== null)
-      ? ServerMessage_StreamerDisconnected.fromPartial(object.streamerDisconnected)
-      : undefined;
-    message.notificationBatch = (object.notificationBatch !== undefined && object.notificationBatch !== null)
-      ? ServerMessage_NotificationBatch.fromPartial(object.notificationBatch)
-      : undefined;
-    message.streamConnected = (object.streamConnected !== undefined && object.streamConnected !== null)
-      ? ServerMessage_StreamConnected.fromPartial(object.streamConnected)
-      : undefined;
-    message.streamDisconnected = (object.streamDisconnected !== undefined && object.streamDisconnected !== null)
-      ? ServerMessage_StreamDisconnected.fromPartial(object.streamDisconnected)
-      : undefined;
-    message.hlsPlayable = (object.hlsPlayable !== undefined && object.hlsPlayable !== null)
-      ? ServerMessage_HlsPlayable.fromPartial(object.hlsPlayable)
-      : undefined;
-    message.hlsUploaded = (object.hlsUploaded !== undefined && object.hlsUploaded !== null)
-      ? ServerMessage_HlsUploaded.fromPartial(object.hlsUploaded)
-      : undefined;
-    message.hlsUploadCrashed = (object.hlsUploadCrashed !== undefined && object.hlsUploadCrashed !== null)
-      ? ServerMessage_HlsUploadCrashed.fromPartial(object.hlsUploadCrashed)
-      : undefined;
-    message.componentCrashed = (object.componentCrashed !== undefined && object.componentCrashed !== null)
-      ? ServerMessage_ComponentCrashed.fromPartial(object.componentCrashed)
-      : undefined;
+    message.vadNotification =
+      object.vadNotification !== undefined && object.vadNotification !== null
+        ? ServerMessage_VadNotification.fromPartial(object.vadNotification)
+        : undefined;
+    message.viewerConnected =
+      object.viewerConnected !== undefined && object.viewerConnected !== null
+        ? ServerMessage_ViewerConnected.fromPartial(object.viewerConnected)
+        : undefined;
+    message.viewerDisconnected =
+      object.viewerDisconnected !== undefined && object.viewerDisconnected !== null
+        ? ServerMessage_ViewerDisconnected.fromPartial(object.viewerDisconnected)
+        : undefined;
+    message.streamerConnected =
+      object.streamerConnected !== undefined && object.streamerConnected !== null
+        ? ServerMessage_StreamerConnected.fromPartial(object.streamerConnected)
+        : undefined;
+    message.streamerDisconnected =
+      object.streamerDisconnected !== undefined && object.streamerDisconnected !== null
+        ? ServerMessage_StreamerDisconnected.fromPartial(object.streamerDisconnected)
+        : undefined;
+    message.notificationBatch =
+      object.notificationBatch !== undefined && object.notificationBatch !== null
+        ? ServerMessage_NotificationBatch.fromPartial(object.notificationBatch)
+        : undefined;
+    message.streamConnected =
+      object.streamConnected !== undefined && object.streamConnected !== null
+        ? ServerMessage_StreamConnected.fromPartial(object.streamConnected)
+        : undefined;
+    message.streamDisconnected =
+      object.streamDisconnected !== undefined && object.streamDisconnected !== null
+        ? ServerMessage_StreamDisconnected.fromPartial(object.streamDisconnected)
+        : undefined;
+    message.hlsPlayable =
+      object.hlsPlayable !== undefined && object.hlsPlayable !== null
+        ? ServerMessage_HlsPlayable.fromPartial(object.hlsPlayable)
+        : undefined;
+    message.hlsUploaded =
+      object.hlsUploaded !== undefined && object.hlsUploaded !== null
+        ? ServerMessage_HlsUploaded.fromPartial(object.hlsUploaded)
+        : undefined;
+    message.hlsUploadCrashed =
+      object.hlsUploadCrashed !== undefined && object.hlsUploadCrashed !== null
+        ? ServerMessage_HlsUploadCrashed.fromPartial(object.hlsUploadCrashed)
+        : undefined;
+    message.componentCrashed =
+      object.componentCrashed !== undefined && object.componentCrashed !== null
+        ? ServerMessage_ComponentCrashed.fromPartial(object.componentCrashed)
+        : undefined;
     return message;
   },
 };
 
 function createBaseServerMessage_RoomCrashed(): ServerMessage_RoomCrashed {
-  return { roomId: "" };
+  return { roomId: '' };
 }
 
 export const ServerMessage_RoomCrashed: MessageFns<ServerMessage_RoomCrashed> = {
   encode(message: ServerMessage_RoomCrashed, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     return writer;
@@ -1132,12 +1148,12 @@ export const ServerMessage_RoomCrashed: MessageFns<ServerMessage_RoomCrashed> = 
   },
 
   fromJSON(object: any): ServerMessage_RoomCrashed {
-    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "" };
+    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '' };
   },
 
   toJSON(message: ServerMessage_RoomCrashed): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     return obj;
@@ -1148,21 +1164,21 @@ export const ServerMessage_RoomCrashed: MessageFns<ServerMessage_RoomCrashed> = 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_RoomCrashed>, I>>(object: I): ServerMessage_RoomCrashed {
     const message = createBaseServerMessage_RoomCrashed();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_PeerAdded(): ServerMessage_PeerAdded {
-  return { roomId: "", peerId: "", peerType: 0 };
+  return { roomId: '', peerId: '', peerType: 0 };
 }
 
 export const ServerMessage_PeerAdded: MessageFns<ServerMessage_PeerAdded> = {
   encode(message: ServerMessage_PeerAdded, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
     if (message.peerType !== 0) {
@@ -1213,18 +1229,18 @@ export const ServerMessage_PeerAdded: MessageFns<ServerMessage_PeerAdded> = {
 
   fromJSON(object: any): ServerMessage_PeerAdded {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
       peerType: isSet(object.peerType) ? serverMessage_PeerTypeFromJSON(object.peerType) : 0,
     };
   },
 
   toJSON(message: ServerMessage_PeerAdded): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
     if (message.peerType !== 0) {
@@ -1238,23 +1254,23 @@ export const ServerMessage_PeerAdded: MessageFns<ServerMessage_PeerAdded> = {
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_PeerAdded>, I>>(object: I): ServerMessage_PeerAdded {
     const message = createBaseServerMessage_PeerAdded();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
     message.peerType = object.peerType ?? 0;
     return message;
   },
 };
 
 function createBaseServerMessage_PeerDeleted(): ServerMessage_PeerDeleted {
-  return { roomId: "", peerId: "", peerType: 0 };
+  return { roomId: '', peerId: '', peerType: 0 };
 }
 
 export const ServerMessage_PeerDeleted: MessageFns<ServerMessage_PeerDeleted> = {
   encode(message: ServerMessage_PeerDeleted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
     if (message.peerType !== 0) {
@@ -1305,18 +1321,18 @@ export const ServerMessage_PeerDeleted: MessageFns<ServerMessage_PeerDeleted> = 
 
   fromJSON(object: any): ServerMessage_PeerDeleted {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
       peerType: isSet(object.peerType) ? serverMessage_PeerTypeFromJSON(object.peerType) : 0,
     };
   },
 
   toJSON(message: ServerMessage_PeerDeleted): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
     if (message.peerType !== 0) {
@@ -1330,23 +1346,23 @@ export const ServerMessage_PeerDeleted: MessageFns<ServerMessage_PeerDeleted> = 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_PeerDeleted>, I>>(object: I): ServerMessage_PeerDeleted {
     const message = createBaseServerMessage_PeerDeleted();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
     message.peerType = object.peerType ?? 0;
     return message;
   },
 };
 
 function createBaseServerMessage_PeerConnected(): ServerMessage_PeerConnected {
-  return { roomId: "", peerId: "", peerType: 0 };
+  return { roomId: '', peerId: '', peerType: 0 };
 }
 
 export const ServerMessage_PeerConnected: MessageFns<ServerMessage_PeerConnected> = {
   encode(message: ServerMessage_PeerConnected, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
     if (message.peerType !== 0) {
@@ -1397,18 +1413,18 @@ export const ServerMessage_PeerConnected: MessageFns<ServerMessage_PeerConnected
 
   fromJSON(object: any): ServerMessage_PeerConnected {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
       peerType: isSet(object.peerType) ? serverMessage_PeerTypeFromJSON(object.peerType) : 0,
     };
   },
 
   toJSON(message: ServerMessage_PeerConnected): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
     if (message.peerType !== 0) {
@@ -1422,23 +1438,23 @@ export const ServerMessage_PeerConnected: MessageFns<ServerMessage_PeerConnected
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_PeerConnected>, I>>(object: I): ServerMessage_PeerConnected {
     const message = createBaseServerMessage_PeerConnected();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
     message.peerType = object.peerType ?? 0;
     return message;
   },
 };
 
 function createBaseServerMessage_PeerDisconnected(): ServerMessage_PeerDisconnected {
-  return { roomId: "", peerId: "", peerType: 0 };
+  return { roomId: '', peerId: '', peerType: 0 };
 }
 
 export const ServerMessage_PeerDisconnected: MessageFns<ServerMessage_PeerDisconnected> = {
   encode(message: ServerMessage_PeerDisconnected, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
     if (message.peerType !== 0) {
@@ -1489,18 +1505,18 @@ export const ServerMessage_PeerDisconnected: MessageFns<ServerMessage_PeerDiscon
 
   fromJSON(object: any): ServerMessage_PeerDisconnected {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
       peerType: isSet(object.peerType) ? serverMessage_PeerTypeFromJSON(object.peerType) : 0,
     };
   },
 
   toJSON(message: ServerMessage_PeerDisconnected): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
     if (message.peerType !== 0) {
@@ -1513,29 +1529,29 @@ export const ServerMessage_PeerDisconnected: MessageFns<ServerMessage_PeerDiscon
     return ServerMessage_PeerDisconnected.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_PeerDisconnected>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_PeerDisconnected {
     const message = createBaseServerMessage_PeerDisconnected();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
     message.peerType = object.peerType ?? 0;
     return message;
   },
 };
 
 function createBaseServerMessage_PeerCrashed(): ServerMessage_PeerCrashed {
-  return { roomId: "", peerId: "", reason: "", peerType: 0 };
+  return { roomId: '', peerId: '', reason: '', peerType: 0 };
 }
 
 export const ServerMessage_PeerCrashed: MessageFns<ServerMessage_PeerCrashed> = {
   encode(message: ServerMessage_PeerCrashed, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
-    if (message.reason !== "") {
+    if (message.reason !== '') {
       writer.uint32(26).string(message.reason);
     }
     if (message.peerType !== 0) {
@@ -1594,22 +1610,22 @@ export const ServerMessage_PeerCrashed: MessageFns<ServerMessage_PeerCrashed> = 
 
   fromJSON(object: any): ServerMessage_PeerCrashed {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
-      reason: isSet(object.reason) ? globalThis.String(object.reason) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
+      reason: isSet(object.reason) ? globalThis.String(object.reason) : '',
       peerType: isSet(object.peerType) ? serverMessage_PeerTypeFromJSON(object.peerType) : 0,
     };
   },
 
   toJSON(message: ServerMessage_PeerCrashed): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
-    if (message.reason !== "") {
+    if (message.reason !== '') {
       obj.reason = message.reason;
     }
     if (message.peerType !== 0) {
@@ -1623,24 +1639,24 @@ export const ServerMessage_PeerCrashed: MessageFns<ServerMessage_PeerCrashed> = 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_PeerCrashed>, I>>(object: I): ServerMessage_PeerCrashed {
     const message = createBaseServerMessage_PeerCrashed();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
-    message.reason = object.reason ?? "";
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
+    message.reason = object.reason ?? '';
     message.peerType = object.peerType ?? 0;
     return message;
   },
 };
 
 function createBaseServerMessage_ComponentCrashed(): ServerMessage_ComponentCrashed {
-  return { roomId: "", componentId: "" };
+  return { roomId: '', componentId: '' };
 }
 
 export const ServerMessage_ComponentCrashed: MessageFns<ServerMessage_ComponentCrashed> = {
   encode(message: ServerMessage_ComponentCrashed, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.componentId !== "") {
+    if (message.componentId !== '') {
       writer.uint32(18).string(message.componentId);
     }
     return writer;
@@ -1680,17 +1696,17 @@ export const ServerMessage_ComponentCrashed: MessageFns<ServerMessage_ComponentC
 
   fromJSON(object: any): ServerMessage_ComponentCrashed {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : '',
     };
   },
 
   toJSON(message: ServerMessage_ComponentCrashed): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.componentId !== "") {
+    if (message.componentId !== '') {
       obj.componentId = message.componentId;
     }
     return obj;
@@ -1700,11 +1716,11 @@ export const ServerMessage_ComponentCrashed: MessageFns<ServerMessage_ComponentC
     return ServerMessage_ComponentCrashed.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_ComponentCrashed>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_ComponentCrashed {
     const message = createBaseServerMessage_ComponentCrashed();
-    message.roomId = object.roomId ?? "";
-    message.componentId = object.componentId ?? "";
+    message.roomId = object.roomId ?? '';
+    message.componentId = object.componentId ?? '';
     return message;
   },
 };
@@ -1753,12 +1769,12 @@ export const ServerMessage_Authenticated: MessageFns<ServerMessage_Authenticated
 };
 
 function createBaseServerMessage_AuthRequest(): ServerMessage_AuthRequest {
-  return { token: "" };
+  return { token: '' };
 }
 
 export const ServerMessage_AuthRequest: MessageFns<ServerMessage_AuthRequest> = {
   encode(message: ServerMessage_AuthRequest, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.token !== "") {
+    if (message.token !== '') {
       writer.uint32(10).string(message.token);
     }
     return writer;
@@ -1789,12 +1805,12 @@ export const ServerMessage_AuthRequest: MessageFns<ServerMessage_AuthRequest> = 
   },
 
   fromJSON(object: any): ServerMessage_AuthRequest {
-    return { token: isSet(object.token) ? globalThis.String(object.token) : "" };
+    return { token: isSet(object.token) ? globalThis.String(object.token) : '' };
   },
 
   toJSON(message: ServerMessage_AuthRequest): unknown {
     const obj: any = {};
-    if (message.token !== "") {
+    if (message.token !== '') {
       obj.token = message.token;
     }
     return obj;
@@ -1805,7 +1821,7 @@ export const ServerMessage_AuthRequest: MessageFns<ServerMessage_AuthRequest> = 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_AuthRequest>, I>>(object: I): ServerMessage_AuthRequest {
     const message = createBaseServerMessage_AuthRequest();
-    message.token = object.token ?? "";
+    message.token = object.token ?? '';
     return message;
   },
 };
@@ -1862,7 +1878,7 @@ export const ServerMessage_SubscribeRequest: MessageFns<ServerMessage_SubscribeR
     return ServerMessage_SubscribeRequest.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_SubscribeRequest>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_SubscribeRequest {
     const message = createBaseServerMessage_SubscribeRequest();
     message.eventType = object.eventType ?? 0;
@@ -1922,7 +1938,7 @@ export const ServerMessage_SubscribeResponse: MessageFns<ServerMessage_Subscribe
     return ServerMessage_SubscribeResponse.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_SubscribeResponse>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_SubscribeResponse {
     const message = createBaseServerMessage_SubscribeResponse();
     message.eventType = object.eventType ?? 0;
@@ -1931,12 +1947,12 @@ export const ServerMessage_SubscribeResponse: MessageFns<ServerMessage_Subscribe
 };
 
 function createBaseServerMessage_RoomCreated(): ServerMessage_RoomCreated {
-  return { roomId: "" };
+  return { roomId: '' };
 }
 
 export const ServerMessage_RoomCreated: MessageFns<ServerMessage_RoomCreated> = {
   encode(message: ServerMessage_RoomCreated, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     return writer;
@@ -1967,12 +1983,12 @@ export const ServerMessage_RoomCreated: MessageFns<ServerMessage_RoomCreated> = 
   },
 
   fromJSON(object: any): ServerMessage_RoomCreated {
-    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "" };
+    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '' };
   },
 
   toJSON(message: ServerMessage_RoomCreated): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     return obj;
@@ -1983,18 +1999,18 @@ export const ServerMessage_RoomCreated: MessageFns<ServerMessage_RoomCreated> = 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_RoomCreated>, I>>(object: I): ServerMessage_RoomCreated {
     const message = createBaseServerMessage_RoomCreated();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_RoomDeleted(): ServerMessage_RoomDeleted {
-  return { roomId: "" };
+  return { roomId: '' };
 }
 
 export const ServerMessage_RoomDeleted: MessageFns<ServerMessage_RoomDeleted> = {
   encode(message: ServerMessage_RoomDeleted, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     return writer;
@@ -2025,12 +2041,12 @@ export const ServerMessage_RoomDeleted: MessageFns<ServerMessage_RoomDeleted> = 
   },
 
   fromJSON(object: any): ServerMessage_RoomDeleted {
-    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "" };
+    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '' };
   },
 
   toJSON(message: ServerMessage_RoomDeleted): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     return obj;
@@ -2041,21 +2057,21 @@ export const ServerMessage_RoomDeleted: MessageFns<ServerMessage_RoomDeleted> = 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_RoomDeleted>, I>>(object: I): ServerMessage_RoomDeleted {
     const message = createBaseServerMessage_RoomDeleted();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_HlsPlayable(): ServerMessage_HlsPlayable {
-  return { roomId: "", componentId: "" };
+  return { roomId: '', componentId: '' };
 }
 
 export const ServerMessage_HlsPlayable: MessageFns<ServerMessage_HlsPlayable> = {
   encode(message: ServerMessage_HlsPlayable, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.componentId !== "") {
+    if (message.componentId !== '') {
       writer.uint32(18).string(message.componentId);
     }
     return writer;
@@ -2095,17 +2111,17 @@ export const ServerMessage_HlsPlayable: MessageFns<ServerMessage_HlsPlayable> = 
 
   fromJSON(object: any): ServerMessage_HlsPlayable {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : '',
     };
   },
 
   toJSON(message: ServerMessage_HlsPlayable): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.componentId !== "") {
+    if (message.componentId !== '') {
       obj.componentId = message.componentId;
     }
     return obj;
@@ -2116,19 +2132,19 @@ export const ServerMessage_HlsPlayable: MessageFns<ServerMessage_HlsPlayable> = 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_HlsPlayable>, I>>(object: I): ServerMessage_HlsPlayable {
     const message = createBaseServerMessage_HlsPlayable();
-    message.roomId = object.roomId ?? "";
-    message.componentId = object.componentId ?? "";
+    message.roomId = object.roomId ?? '';
+    message.componentId = object.componentId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_HlsUploaded(): ServerMessage_HlsUploaded {
-  return { roomId: "" };
+  return { roomId: '' };
 }
 
 export const ServerMessage_HlsUploaded: MessageFns<ServerMessage_HlsUploaded> = {
   encode(message: ServerMessage_HlsUploaded, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     return writer;
@@ -2159,12 +2175,12 @@ export const ServerMessage_HlsUploaded: MessageFns<ServerMessage_HlsUploaded> = 
   },
 
   fromJSON(object: any): ServerMessage_HlsUploaded {
-    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "" };
+    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '' };
   },
 
   toJSON(message: ServerMessage_HlsUploaded): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     return obj;
@@ -2175,18 +2191,18 @@ export const ServerMessage_HlsUploaded: MessageFns<ServerMessage_HlsUploaded> = 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_HlsUploaded>, I>>(object: I): ServerMessage_HlsUploaded {
     const message = createBaseServerMessage_HlsUploaded();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_HlsUploadCrashed(): ServerMessage_HlsUploadCrashed {
-  return { roomId: "" };
+  return { roomId: '' };
 }
 
 export const ServerMessage_HlsUploadCrashed: MessageFns<ServerMessage_HlsUploadCrashed> = {
   encode(message: ServerMessage_HlsUploadCrashed, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     return writer;
@@ -2217,12 +2233,12 @@ export const ServerMessage_HlsUploadCrashed: MessageFns<ServerMessage_HlsUploadC
   },
 
   fromJSON(object: any): ServerMessage_HlsUploadCrashed {
-    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "" };
+    return { roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '' };
   },
 
   toJSON(message: ServerMessage_HlsUploadCrashed): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     return obj;
@@ -2232,27 +2248,27 @@ export const ServerMessage_HlsUploadCrashed: MessageFns<ServerMessage_HlsUploadC
     return ServerMessage_HlsUploadCrashed.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_HlsUploadCrashed>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_HlsUploadCrashed {
     const message = createBaseServerMessage_HlsUploadCrashed();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_PeerMetadataUpdated(): ServerMessage_PeerMetadataUpdated {
-  return { roomId: "", peerId: "", metadata: "", peerType: 0 };
+  return { roomId: '', peerId: '', metadata: '', peerType: 0 };
 }
 
 export const ServerMessage_PeerMetadataUpdated: MessageFns<ServerMessage_PeerMetadataUpdated> = {
   encode(message: ServerMessage_PeerMetadataUpdated, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== '') {
       writer.uint32(26).string(message.metadata);
     }
     if (message.peerType !== 0) {
@@ -2311,22 +2327,22 @@ export const ServerMessage_PeerMetadataUpdated: MessageFns<ServerMessage_PeerMet
 
   fromJSON(object: any): ServerMessage_PeerMetadataUpdated {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
-      metadata: isSet(object.metadata) ? globalThis.String(object.metadata) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
+      metadata: isSet(object.metadata) ? globalThis.String(object.metadata) : '',
       peerType: isSet(object.peerType) ? serverMessage_PeerTypeFromJSON(object.peerType) : 0,
     };
   },
 
   toJSON(message: ServerMessage_PeerMetadataUpdated): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
-    if (message.metadata !== "") {
+    if (message.metadata !== '') {
       obj.metadata = message.metadata;
     }
     if (message.peerType !== 0) {
@@ -2336,29 +2352,29 @@ export const ServerMessage_PeerMetadataUpdated: MessageFns<ServerMessage_PeerMet
   },
 
   create<I extends Exact<DeepPartial<ServerMessage_PeerMetadataUpdated>, I>>(
-    base?: I,
+    base?: I
   ): ServerMessage_PeerMetadataUpdated {
     return ServerMessage_PeerMetadataUpdated.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_PeerMetadataUpdated>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_PeerMetadataUpdated {
     const message = createBaseServerMessage_PeerMetadataUpdated();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
-    message.metadata = object.metadata ?? "";
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
+    message.metadata = object.metadata ?? '';
     message.peerType = object.peerType ?? 0;
     return message;
   },
 };
 
 function createBaseServerMessage_TrackAdded(): ServerMessage_TrackAdded {
-  return { roomId: "", peerId: undefined, componentId: undefined, track: undefined };
+  return { roomId: '', peerId: undefined, componentId: undefined, track: undefined };
 }
 
 export const ServerMessage_TrackAdded: MessageFns<ServerMessage_TrackAdded> = {
   encode(message: ServerMessage_TrackAdded, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     if (message.peerId !== undefined) {
@@ -2423,7 +2439,7 @@ export const ServerMessage_TrackAdded: MessageFns<ServerMessage_TrackAdded> = {
 
   fromJSON(object: any): ServerMessage_TrackAdded {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
       peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : undefined,
       componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : undefined,
       track: isSet(object.track) ? Track.fromJSON(object.track) : undefined,
@@ -2432,7 +2448,7 @@ export const ServerMessage_TrackAdded: MessageFns<ServerMessage_TrackAdded> = {
 
   toJSON(message: ServerMessage_TrackAdded): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     if (message.peerId !== undefined) {
@@ -2452,21 +2468,21 @@ export const ServerMessage_TrackAdded: MessageFns<ServerMessage_TrackAdded> = {
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_TrackAdded>, I>>(object: I): ServerMessage_TrackAdded {
     const message = createBaseServerMessage_TrackAdded();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     message.peerId = object.peerId ?? undefined;
     message.componentId = object.componentId ?? undefined;
-    message.track = (object.track !== undefined && object.track !== null) ? Track.fromPartial(object.track) : undefined;
+    message.track = object.track !== undefined && object.track !== null ? Track.fromPartial(object.track) : undefined;
     return message;
   },
 };
 
 function createBaseServerMessage_TrackRemoved(): ServerMessage_TrackRemoved {
-  return { roomId: "", peerId: undefined, componentId: undefined, track: undefined };
+  return { roomId: '', peerId: undefined, componentId: undefined, track: undefined };
 }
 
 export const ServerMessage_TrackRemoved: MessageFns<ServerMessage_TrackRemoved> = {
   encode(message: ServerMessage_TrackRemoved, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     if (message.peerId !== undefined) {
@@ -2531,7 +2547,7 @@ export const ServerMessage_TrackRemoved: MessageFns<ServerMessage_TrackRemoved> 
 
   fromJSON(object: any): ServerMessage_TrackRemoved {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
       peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : undefined,
       componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : undefined,
       track: isSet(object.track) ? Track.fromJSON(object.track) : undefined,
@@ -2540,7 +2556,7 @@ export const ServerMessage_TrackRemoved: MessageFns<ServerMessage_TrackRemoved> 
 
   toJSON(message: ServerMessage_TrackRemoved): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     if (message.peerId !== undefined) {
@@ -2560,21 +2576,21 @@ export const ServerMessage_TrackRemoved: MessageFns<ServerMessage_TrackRemoved> 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_TrackRemoved>, I>>(object: I): ServerMessage_TrackRemoved {
     const message = createBaseServerMessage_TrackRemoved();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     message.peerId = object.peerId ?? undefined;
     message.componentId = object.componentId ?? undefined;
-    message.track = (object.track !== undefined && object.track !== null) ? Track.fromPartial(object.track) : undefined;
+    message.track = object.track !== undefined && object.track !== null ? Track.fromPartial(object.track) : undefined;
     return message;
   },
 };
 
 function createBaseServerMessage_TrackMetadataUpdated(): ServerMessage_TrackMetadataUpdated {
-  return { roomId: "", peerId: undefined, componentId: undefined, track: undefined };
+  return { roomId: '', peerId: undefined, componentId: undefined, track: undefined };
 }
 
 export const ServerMessage_TrackMetadataUpdated: MessageFns<ServerMessage_TrackMetadataUpdated> = {
   encode(message: ServerMessage_TrackMetadataUpdated, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     if (message.peerId !== undefined) {
@@ -2639,7 +2655,7 @@ export const ServerMessage_TrackMetadataUpdated: MessageFns<ServerMessage_TrackM
 
   fromJSON(object: any): ServerMessage_TrackMetadataUpdated {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
       peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : undefined,
       componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : undefined,
       track: isSet(object.track) ? Track.fromJSON(object.track) : undefined,
@@ -2648,7 +2664,7 @@ export const ServerMessage_TrackMetadataUpdated: MessageFns<ServerMessage_TrackM
 
   toJSON(message: ServerMessage_TrackMetadataUpdated): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     if (message.peerId !== undefined) {
@@ -2664,29 +2680,29 @@ export const ServerMessage_TrackMetadataUpdated: MessageFns<ServerMessage_TrackM
   },
 
   create<I extends Exact<DeepPartial<ServerMessage_TrackMetadataUpdated>, I>>(
-    base?: I,
+    base?: I
   ): ServerMessage_TrackMetadataUpdated {
     return ServerMessage_TrackMetadataUpdated.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_TrackMetadataUpdated>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_TrackMetadataUpdated {
     const message = createBaseServerMessage_TrackMetadataUpdated();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     message.peerId = object.peerId ?? undefined;
     message.componentId = object.componentId ?? undefined;
-    message.track = (object.track !== undefined && object.track !== null) ? Track.fromPartial(object.track) : undefined;
+    message.track = object.track !== undefined && object.track !== null ? Track.fromPartial(object.track) : undefined;
     return message;
   },
 };
 
 function createBaseServerMessage_ChannelAdded(): ServerMessage_ChannelAdded {
-  return { roomId: "", peerId: undefined, componentId: undefined, channelId: "" };
+  return { roomId: '', peerId: undefined, componentId: undefined, channelId: '' };
 }
 
 export const ServerMessage_ChannelAdded: MessageFns<ServerMessage_ChannelAdded> = {
   encode(message: ServerMessage_ChannelAdded, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     if (message.peerId !== undefined) {
@@ -2695,7 +2711,7 @@ export const ServerMessage_ChannelAdded: MessageFns<ServerMessage_ChannelAdded> 
     if (message.componentId !== undefined) {
       writer.uint32(26).string(message.componentId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== '') {
       writer.uint32(34).string(message.channelId);
     }
     return writer;
@@ -2751,16 +2767,16 @@ export const ServerMessage_ChannelAdded: MessageFns<ServerMessage_ChannelAdded> 
 
   fromJSON(object: any): ServerMessage_ChannelAdded {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
       peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : undefined,
       componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : undefined,
-      channelId: isSet(object.channelId) ? globalThis.String(object.channelId) : "",
+      channelId: isSet(object.channelId) ? globalThis.String(object.channelId) : '',
     };
   },
 
   toJSON(message: ServerMessage_ChannelAdded): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     if (message.peerId !== undefined) {
@@ -2769,7 +2785,7 @@ export const ServerMessage_ChannelAdded: MessageFns<ServerMessage_ChannelAdded> 
     if (message.componentId !== undefined) {
       obj.componentId = message.componentId;
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== '') {
       obj.channelId = message.channelId;
     }
     return obj;
@@ -2780,21 +2796,21 @@ export const ServerMessage_ChannelAdded: MessageFns<ServerMessage_ChannelAdded> 
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_ChannelAdded>, I>>(object: I): ServerMessage_ChannelAdded {
     const message = createBaseServerMessage_ChannelAdded();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     message.peerId = object.peerId ?? undefined;
     message.componentId = object.componentId ?? undefined;
-    message.channelId = object.channelId ?? "";
+    message.channelId = object.channelId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_ChannelRemoved(): ServerMessage_ChannelRemoved {
-  return { roomId: "", peerId: undefined, componentId: undefined, channelId: "" };
+  return { roomId: '', peerId: undefined, componentId: undefined, channelId: '' };
 }
 
 export const ServerMessage_ChannelRemoved: MessageFns<ServerMessage_ChannelRemoved> = {
   encode(message: ServerMessage_ChannelRemoved, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
     if (message.peerId !== undefined) {
@@ -2803,7 +2819,7 @@ export const ServerMessage_ChannelRemoved: MessageFns<ServerMessage_ChannelRemov
     if (message.componentId !== undefined) {
       writer.uint32(26).string(message.componentId);
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== '') {
       writer.uint32(34).string(message.channelId);
     }
     return writer;
@@ -2859,16 +2875,16 @@ export const ServerMessage_ChannelRemoved: MessageFns<ServerMessage_ChannelRemov
 
   fromJSON(object: any): ServerMessage_ChannelRemoved {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
       peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : undefined,
       componentId: isSet(object.componentId) ? globalThis.String(object.componentId) : undefined,
-      channelId: isSet(object.channelId) ? globalThis.String(object.channelId) : "",
+      channelId: isSet(object.channelId) ? globalThis.String(object.channelId) : '',
     };
   },
 
   toJSON(message: ServerMessage_ChannelRemoved): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
     if (message.peerId !== undefined) {
@@ -2877,7 +2893,7 @@ export const ServerMessage_ChannelRemoved: MessageFns<ServerMessage_ChannelRemov
     if (message.componentId !== undefined) {
       obj.componentId = message.componentId;
     }
-    if (message.channelId !== "") {
+    if (message.channelId !== '') {
       obj.channelId = message.channelId;
     }
     return obj;
@@ -2888,30 +2904,30 @@ export const ServerMessage_ChannelRemoved: MessageFns<ServerMessage_ChannelRemov
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_ChannelRemoved>, I>>(object: I): ServerMessage_ChannelRemoved {
     const message = createBaseServerMessage_ChannelRemoved();
-    message.roomId = object.roomId ?? "";
+    message.roomId = object.roomId ?? '';
     message.peerId = object.peerId ?? undefined;
     message.componentId = object.componentId ?? undefined;
-    message.channelId = object.channelId ?? "";
+    message.channelId = object.channelId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_TrackForwarding(): ServerMessage_TrackForwarding {
-  return { roomId: "", peerId: "", compositionUrl: "", inputId: "", audioTrack: undefined, videoTrack: undefined };
+  return { roomId: '', peerId: '', compositionUrl: '', inputId: '', audioTrack: undefined, videoTrack: undefined };
 }
 
 export const ServerMessage_TrackForwarding: MessageFns<ServerMessage_TrackForwarding> = {
   encode(message: ServerMessage_TrackForwarding, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
-    if (message.compositionUrl !== "") {
+    if (message.compositionUrl !== '') {
       writer.uint32(26).string(message.compositionUrl);
     }
-    if (message.inputId !== "") {
+    if (message.inputId !== '') {
       writer.uint32(34).string(message.inputId);
     }
     if (message.audioTrack !== undefined) {
@@ -2989,10 +3005,10 @@ export const ServerMessage_TrackForwarding: MessageFns<ServerMessage_TrackForwar
 
   fromJSON(object: any): ServerMessage_TrackForwarding {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
-      compositionUrl: isSet(object.compositionUrl) ? globalThis.String(object.compositionUrl) : "",
-      inputId: isSet(object.inputId) ? globalThis.String(object.inputId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
+      compositionUrl: isSet(object.compositionUrl) ? globalThis.String(object.compositionUrl) : '',
+      inputId: isSet(object.inputId) ? globalThis.String(object.inputId) : '',
       audioTrack: isSet(object.audioTrack) ? Track.fromJSON(object.audioTrack) : undefined,
       videoTrack: isSet(object.videoTrack) ? Track.fromJSON(object.videoTrack) : undefined,
     };
@@ -3000,16 +3016,16 @@ export const ServerMessage_TrackForwarding: MessageFns<ServerMessage_TrackForwar
 
   toJSON(message: ServerMessage_TrackForwarding): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
-    if (message.compositionUrl !== "") {
+    if (message.compositionUrl !== '') {
       obj.compositionUrl = message.compositionUrl;
     }
-    if (message.inputId !== "") {
+    if (message.inputId !== '') {
       obj.inputId = message.inputId;
     }
     if (message.audioTrack !== undefined) {
@@ -3025,39 +3041,37 @@ export const ServerMessage_TrackForwarding: MessageFns<ServerMessage_TrackForwar
     return ServerMessage_TrackForwarding.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_TrackForwarding>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_TrackForwarding {
     const message = createBaseServerMessage_TrackForwarding();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
-    message.compositionUrl = object.compositionUrl ?? "";
-    message.inputId = object.inputId ?? "";
-    message.audioTrack = (object.audioTrack !== undefined && object.audioTrack !== null)
-      ? Track.fromPartial(object.audioTrack)
-      : undefined;
-    message.videoTrack = (object.videoTrack !== undefined && object.videoTrack !== null)
-      ? Track.fromPartial(object.videoTrack)
-      : undefined;
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
+    message.compositionUrl = object.compositionUrl ?? '';
+    message.inputId = object.inputId ?? '';
+    message.audioTrack =
+      object.audioTrack !== undefined && object.audioTrack !== null ? Track.fromPartial(object.audioTrack) : undefined;
+    message.videoTrack =
+      object.videoTrack !== undefined && object.videoTrack !== null ? Track.fromPartial(object.videoTrack) : undefined;
     return message;
   },
 };
 
 function createBaseServerMessage_TrackForwardingRemoved(): ServerMessage_TrackForwardingRemoved {
-  return { roomId: "", peerId: "", compositionUrl: "", inputId: "" };
+  return { roomId: '', peerId: '', compositionUrl: '', inputId: '' };
 }
 
 export const ServerMessage_TrackForwardingRemoved: MessageFns<ServerMessage_TrackForwardingRemoved> = {
   encode(message: ServerMessage_TrackForwardingRemoved, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
-    if (message.compositionUrl !== "") {
+    if (message.compositionUrl !== '') {
       writer.uint32(26).string(message.compositionUrl);
     }
-    if (message.inputId !== "") {
+    if (message.inputId !== '') {
       writer.uint32(34).string(message.inputId);
     }
     return writer;
@@ -3113,60 +3127,60 @@ export const ServerMessage_TrackForwardingRemoved: MessageFns<ServerMessage_Trac
 
   fromJSON(object: any): ServerMessage_TrackForwardingRemoved {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
-      compositionUrl: isSet(object.compositionUrl) ? globalThis.String(object.compositionUrl) : "",
-      inputId: isSet(object.inputId) ? globalThis.String(object.inputId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
+      compositionUrl: isSet(object.compositionUrl) ? globalThis.String(object.compositionUrl) : '',
+      inputId: isSet(object.inputId) ? globalThis.String(object.inputId) : '',
     };
   },
 
   toJSON(message: ServerMessage_TrackForwardingRemoved): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
-    if (message.compositionUrl !== "") {
+    if (message.compositionUrl !== '') {
       obj.compositionUrl = message.compositionUrl;
     }
-    if (message.inputId !== "") {
+    if (message.inputId !== '') {
       obj.inputId = message.inputId;
     }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<ServerMessage_TrackForwardingRemoved>, I>>(
-    base?: I,
+    base?: I
   ): ServerMessage_TrackForwardingRemoved {
     return ServerMessage_TrackForwardingRemoved.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_TrackForwardingRemoved>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_TrackForwardingRemoved {
     const message = createBaseServerMessage_TrackForwardingRemoved();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
-    message.compositionUrl = object.compositionUrl ?? "";
-    message.inputId = object.inputId ?? "";
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
+    message.compositionUrl = object.compositionUrl ?? '';
+    message.inputId = object.inputId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_VadNotification(): ServerMessage_VadNotification {
-  return { roomId: "", peerId: "", trackId: "", status: 0 };
+  return { roomId: '', peerId: '', trackId: '', status: 0 };
 }
 
 export const ServerMessage_VadNotification: MessageFns<ServerMessage_VadNotification> = {
   encode(message: ServerMessage_VadNotification, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       writer.uint32(10).string(message.roomId);
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       writer.uint32(18).string(message.peerId);
     }
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       writer.uint32(26).string(message.trackId);
     }
     if (message.status !== 0) {
@@ -3225,22 +3239,22 @@ export const ServerMessage_VadNotification: MessageFns<ServerMessage_VadNotifica
 
   fromJSON(object: any): ServerMessage_VadNotification {
     return {
-      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : "",
-      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : "",
-      trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : "",
+      roomId: isSet(object.roomId) ? globalThis.String(object.roomId) : '',
+      peerId: isSet(object.peerId) ? globalThis.String(object.peerId) : '',
+      trackId: isSet(object.trackId) ? globalThis.String(object.trackId) : '',
       status: isSet(object.status) ? serverMessage_VadNotification_StatusFromJSON(object.status) : 0,
     };
   },
 
   toJSON(message: ServerMessage_VadNotification): unknown {
     const obj: any = {};
-    if (message.roomId !== "") {
+    if (message.roomId !== '') {
       obj.roomId = message.roomId;
     }
-    if (message.peerId !== "") {
+    if (message.peerId !== '') {
       obj.peerId = message.peerId;
     }
-    if (message.trackId !== "") {
+    if (message.trackId !== '') {
       obj.trackId = message.trackId;
     }
     if (message.status !== 0) {
@@ -3253,24 +3267,24 @@ export const ServerMessage_VadNotification: MessageFns<ServerMessage_VadNotifica
     return ServerMessage_VadNotification.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_VadNotification>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_VadNotification {
     const message = createBaseServerMessage_VadNotification();
-    message.roomId = object.roomId ?? "";
-    message.peerId = object.peerId ?? "";
-    message.trackId = object.trackId ?? "";
+    message.roomId = object.roomId ?? '';
+    message.peerId = object.peerId ?? '';
+    message.trackId = object.trackId ?? '';
     message.status = object.status ?? 0;
     return message;
   },
 };
 
 function createBaseServerMessage_StreamConnected(): ServerMessage_StreamConnected {
-  return { streamId: "" };
+  return { streamId: '' };
 }
 
 export const ServerMessage_StreamConnected: MessageFns<ServerMessage_StreamConnected> = {
   encode(message: ServerMessage_StreamConnected, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       writer.uint32(10).string(message.streamId);
     }
     return writer;
@@ -3301,12 +3315,12 @@ export const ServerMessage_StreamConnected: MessageFns<ServerMessage_StreamConne
   },
 
   fromJSON(object: any): ServerMessage_StreamConnected {
-    return { streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : "" };
+    return { streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : '' };
   },
 
   toJSON(message: ServerMessage_StreamConnected): unknown {
     const obj: any = {};
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       obj.streamId = message.streamId;
     }
     return obj;
@@ -3316,21 +3330,21 @@ export const ServerMessage_StreamConnected: MessageFns<ServerMessage_StreamConne
     return ServerMessage_StreamConnected.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_StreamConnected>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_StreamConnected {
     const message = createBaseServerMessage_StreamConnected();
-    message.streamId = object.streamId ?? "";
+    message.streamId = object.streamId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_StreamDisconnected(): ServerMessage_StreamDisconnected {
-  return { streamId: "" };
+  return { streamId: '' };
 }
 
 export const ServerMessage_StreamDisconnected: MessageFns<ServerMessage_StreamDisconnected> = {
   encode(message: ServerMessage_StreamDisconnected, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       writer.uint32(10).string(message.streamId);
     }
     return writer;
@@ -3361,41 +3375,41 @@ export const ServerMessage_StreamDisconnected: MessageFns<ServerMessage_StreamDi
   },
 
   fromJSON(object: any): ServerMessage_StreamDisconnected {
-    return { streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : "" };
+    return { streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : '' };
   },
 
   toJSON(message: ServerMessage_StreamDisconnected): unknown {
     const obj: any = {};
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       obj.streamId = message.streamId;
     }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<ServerMessage_StreamDisconnected>, I>>(
-    base?: I,
+    base?: I
   ): ServerMessage_StreamDisconnected {
     return ServerMessage_StreamDisconnected.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_StreamDisconnected>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_StreamDisconnected {
     const message = createBaseServerMessage_StreamDisconnected();
-    message.streamId = object.streamId ?? "";
+    message.streamId = object.streamId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_ViewerConnected(): ServerMessage_ViewerConnected {
-  return { streamId: "", viewerId: "" };
+  return { streamId: '', viewerId: '' };
 }
 
 export const ServerMessage_ViewerConnected: MessageFns<ServerMessage_ViewerConnected> = {
   encode(message: ServerMessage_ViewerConnected, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       writer.uint32(10).string(message.streamId);
     }
-    if (message.viewerId !== "") {
+    if (message.viewerId !== '') {
       writer.uint32(18).string(message.viewerId);
     }
     return writer;
@@ -3435,17 +3449,17 @@ export const ServerMessage_ViewerConnected: MessageFns<ServerMessage_ViewerConne
 
   fromJSON(object: any): ServerMessage_ViewerConnected {
     return {
-      streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : "",
-      viewerId: isSet(object.viewerId) ? globalThis.String(object.viewerId) : "",
+      streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : '',
+      viewerId: isSet(object.viewerId) ? globalThis.String(object.viewerId) : '',
     };
   },
 
   toJSON(message: ServerMessage_ViewerConnected): unknown {
     const obj: any = {};
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       obj.streamId = message.streamId;
     }
-    if (message.viewerId !== "") {
+    if (message.viewerId !== '') {
       obj.viewerId = message.viewerId;
     }
     return obj;
@@ -3455,25 +3469,25 @@ export const ServerMessage_ViewerConnected: MessageFns<ServerMessage_ViewerConne
     return ServerMessage_ViewerConnected.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_ViewerConnected>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_ViewerConnected {
     const message = createBaseServerMessage_ViewerConnected();
-    message.streamId = object.streamId ?? "";
-    message.viewerId = object.viewerId ?? "";
+    message.streamId = object.streamId ?? '';
+    message.viewerId = object.viewerId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_ViewerDisconnected(): ServerMessage_ViewerDisconnected {
-  return { streamId: "", viewerId: "" };
+  return { streamId: '', viewerId: '' };
 }
 
 export const ServerMessage_ViewerDisconnected: MessageFns<ServerMessage_ViewerDisconnected> = {
   encode(message: ServerMessage_ViewerDisconnected, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       writer.uint32(10).string(message.streamId);
     }
-    if (message.viewerId !== "") {
+    if (message.viewerId !== '') {
       writer.uint32(18).string(message.viewerId);
     }
     return writer;
@@ -3513,47 +3527,47 @@ export const ServerMessage_ViewerDisconnected: MessageFns<ServerMessage_ViewerDi
 
   fromJSON(object: any): ServerMessage_ViewerDisconnected {
     return {
-      streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : "",
-      viewerId: isSet(object.viewerId) ? globalThis.String(object.viewerId) : "",
+      streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : '',
+      viewerId: isSet(object.viewerId) ? globalThis.String(object.viewerId) : '',
     };
   },
 
   toJSON(message: ServerMessage_ViewerDisconnected): unknown {
     const obj: any = {};
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       obj.streamId = message.streamId;
     }
-    if (message.viewerId !== "") {
+    if (message.viewerId !== '') {
       obj.viewerId = message.viewerId;
     }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<ServerMessage_ViewerDisconnected>, I>>(
-    base?: I,
+    base?: I
   ): ServerMessage_ViewerDisconnected {
     return ServerMessage_ViewerDisconnected.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_ViewerDisconnected>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_ViewerDisconnected {
     const message = createBaseServerMessage_ViewerDisconnected();
-    message.streamId = object.streamId ?? "";
-    message.viewerId = object.viewerId ?? "";
+    message.streamId = object.streamId ?? '';
+    message.viewerId = object.viewerId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_StreamerConnected(): ServerMessage_StreamerConnected {
-  return { streamId: "", streamerId: "" };
+  return { streamId: '', streamerId: '' };
 }
 
 export const ServerMessage_StreamerConnected: MessageFns<ServerMessage_StreamerConnected> = {
   encode(message: ServerMessage_StreamerConnected, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       writer.uint32(10).string(message.streamId);
     }
-    if (message.streamerId !== "") {
+    if (message.streamerId !== '') {
       writer.uint32(18).string(message.streamerId);
     }
     return writer;
@@ -3593,17 +3607,17 @@ export const ServerMessage_StreamerConnected: MessageFns<ServerMessage_StreamerC
 
   fromJSON(object: any): ServerMessage_StreamerConnected {
     return {
-      streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : "",
-      streamerId: isSet(object.streamerId) ? globalThis.String(object.streamerId) : "",
+      streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : '',
+      streamerId: isSet(object.streamerId) ? globalThis.String(object.streamerId) : '',
     };
   },
 
   toJSON(message: ServerMessage_StreamerConnected): unknown {
     const obj: any = {};
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       obj.streamId = message.streamId;
     }
-    if (message.streamerId !== "") {
+    if (message.streamerId !== '') {
       obj.streamerId = message.streamerId;
     }
     return obj;
@@ -3613,25 +3627,25 @@ export const ServerMessage_StreamerConnected: MessageFns<ServerMessage_StreamerC
     return ServerMessage_StreamerConnected.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_StreamerConnected>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_StreamerConnected {
     const message = createBaseServerMessage_StreamerConnected();
-    message.streamId = object.streamId ?? "";
-    message.streamerId = object.streamerId ?? "";
+    message.streamId = object.streamId ?? '';
+    message.streamerId = object.streamerId ?? '';
     return message;
   },
 };
 
 function createBaseServerMessage_StreamerDisconnected(): ServerMessage_StreamerDisconnected {
-  return { streamId: "", streamerId: "" };
+  return { streamId: '', streamerId: '' };
 }
 
 export const ServerMessage_StreamerDisconnected: MessageFns<ServerMessage_StreamerDisconnected> = {
   encode(message: ServerMessage_StreamerDisconnected, writer: BinaryWriter = new BinaryWriter()): BinaryWriter {
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       writer.uint32(10).string(message.streamId);
     }
-    if (message.streamerId !== "") {
+    if (message.streamerId !== '') {
       writer.uint32(18).string(message.streamerId);
     }
     return writer;
@@ -3671,33 +3685,33 @@ export const ServerMessage_StreamerDisconnected: MessageFns<ServerMessage_Stream
 
   fromJSON(object: any): ServerMessage_StreamerDisconnected {
     return {
-      streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : "",
-      streamerId: isSet(object.streamerId) ? globalThis.String(object.streamerId) : "",
+      streamId: isSet(object.streamId) ? globalThis.String(object.streamId) : '',
+      streamerId: isSet(object.streamerId) ? globalThis.String(object.streamerId) : '',
     };
   },
 
   toJSON(message: ServerMessage_StreamerDisconnected): unknown {
     const obj: any = {};
-    if (message.streamId !== "") {
+    if (message.streamId !== '') {
       obj.streamId = message.streamId;
     }
-    if (message.streamerId !== "") {
+    if (message.streamerId !== '') {
       obj.streamerId = message.streamerId;
     }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<ServerMessage_StreamerDisconnected>, I>>(
-    base?: I,
+    base?: I
   ): ServerMessage_StreamerDisconnected {
     return ServerMessage_StreamerDisconnected.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_StreamerDisconnected>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_StreamerDisconnected {
     const message = createBaseServerMessage_StreamerDisconnected();
-    message.streamId = object.streamId ?? "";
-    message.streamerId = object.streamerId ?? "";
+    message.streamId = object.streamId ?? '';
+    message.streamerId = object.streamerId ?? '';
     return message;
   },
 };
@@ -3758,7 +3772,7 @@ export const ServerMessage_NotificationBatch: MessageFns<ServerMessage_Notificat
     return ServerMessage_NotificationBatch.fromPartial(base ?? ({} as any));
   },
   fromPartial<I extends Exact<DeepPartial<ServerMessage_NotificationBatch>, I>>(
-    object: I,
+    object: I
   ): ServerMessage_NotificationBatch {
     const message = createBaseServerMessage_NotificationBatch();
     message.notifications = object.notifications?.map((e) => ServerMessage.fromPartial(e)) || [];
@@ -3768,14 +3782,19 @@ export const ServerMessage_NotificationBatch: MessageFns<ServerMessage_Notificat
 
 type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends globalThis.Array<infer U> ? globalThis.Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
-  : Partial<T>;
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends globalThis.Array<infer U>
+    ? globalThis.Array<DeepPartial<U>>
+    : T extends ReadonlyArray<infer U>
+      ? ReadonlyArray<DeepPartial<U>>
+      : T extends {}
+        ? { [K in keyof T]?: DeepPartial<T[K]> }
+        : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
   : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 function isSet(value: any): boolean {

--- a/packages/fishjam-proto/src/index.ts
+++ b/packages/fishjam-proto/src/index.ts
@@ -1,5 +1,5 @@
-export * from "./fishjam/server_notifications";
+export * from './fishjam/server_notifications';
 
-export { DeepPartial, Exact, MessageFns, protobufPackage } from "./fishjam/agent_notifications";
-export * from "./fishjam/agent_notifications";
-export * from "./fishjam/notifications/shared";
+export { DeepPartial, Exact, MessageFns, protobufPackage } from './fishjam/agent_notifications';
+export * from './fishjam/agent_notifications';
+export * from './fishjam/notifications/shared';

--- a/release-automation/bump-version.sh
+++ b/release-automation/bump-version.sh
@@ -78,5 +78,10 @@ npx @openapitools/openapi-generator-cli generate \
 rm openapi.yaml
 cd ../../
 
+echo "Formatting generated code..."
+npx prettier --write \
+  "packages/fishjam-openapi/src/generated/**/*.ts" \
+  "packages/fishjam-proto/src/**/*.ts"
+
 echo "✅ Version bump complete for $VERSION"
 echo "BRANCH_NAME:$BRANCH_NAME"


### PR DESCRIPTION
## Problem

The release bot (`release-automation/bump-version.sh`) regenerates the OpenAPI and proto clients during a version bump but never runs prettier on the output, so it commits **raw generator code**. Meanwhile CI's `format:check` only covers the `js-server-sdk` workspace (the only package with a `format` script), so the unformatted generated code in `fishjam-openapi` / `fishjam-proto` is never checked and passes CI unnoticed.

The result: release PRs carry large **no-op formatting diffs**. In v0.28.0 (#277) this showed up as a ~4,500-line `api.ts` diff with **zero actual API change** — purely raw-vs-prettier formatting.

## Fix

1. **`bump-version.sh`** now runs `prettier --write` over the generated openapi/proto output after codegen, so the bot commits formatted code matching repo conventions.
2. **Normalized the existing raw generated files** (`base/common/configuration/index.ts` + the 4 proto files) which were committed raw. `api.ts` was already formatted, so it's untouched here. This makes the repo internally consistent so the *next* no-op release produces a genuinely empty diff.

All changes are formatting-only — `fishjam-openapi` typecheck and `fishjam-proto` build both pass.

## Follow-up (not in this PR)

Consider adding `format`/`format:check` scripts to the `fishjam-openapi` and `fishjam-proto` packages so the root `yarn format:check` (already run in CI) covers generated code too — that would let CI *catch* this class of regression instead of relying on the bot doing the right thing.