### PR TITLE
release 0.29.0-rc.2

### DIFF
--- a/examples/multimodal/package.json
+++ b/examples/multimodal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multimodal-demo",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --write .",

--- a/examples/room-manager/package.json
+++ b/examples/room-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "room-manager",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/examples/selective-subscription/backend/package.json
+++ b/examples/selective-subscription/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selective-subscription-backend",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "typecheck": "tsc --noEmit"

--- a/examples/selective-subscription/frontend/package.json
+++ b/examples/selective-subscription/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "selective-subscription-frontend",
   "private": true,
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/selective-subscription/package.json
+++ b/examples/selective-subscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "selective-subscription-demo",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "workspaces": [
     "frontend",
     "backend"

--- a/examples/transcription/package.json
+++ b/examples/transcription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transcription-demo",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "license": "Apache-2.0",
   "workspaces": [
     "packages/*",

--- a/packages/composition/package.json
+++ b/packages/composition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/composition",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "description": "React hooks and event bus for building Fishjam composition templates",
   "homepage": "https://github.com/fishjam-cloud/js-server-sdk",
   "author": "Fishjam Team",

--- a/packages/fishjam-openapi/package.json
+++ b/packages/fishjam-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/fishjam-openapi",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "private": true,
   "description": "Fishjam OpenAPI",
   "homepage": "https://github.com/fishjam-cloud/js-server-sdk",

--- a/packages/fishjam-proto/package.json
+++ b/packages/fishjam-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/fishjam-proto",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "private": true,
   "description": "Fishjam Proto",
   "homepage": "https://github.com/fishjam-cloud/js-server-sdk",

--- a/packages/js-server-sdk/package.json
+++ b/packages/js-server-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/js-server-sdk",
-  "version": "0.29.0-rc.1",
+  "version": "0.29.0-rc.2",
   "description": "Fishjam server SDK for JavaScript",
   "homepage": "https://github.com/fishjam-cloud/js-server-sdk",
   "author": "Fishjam Team",


### PR DESCRIPTION
Version bump to `0.29.0-rc.2` across all workspaces (mirrors #284).

`0.29.0-rc.1` is already published on npm, so the release workflow 403s on a version collision. This cuts a fresh RC so the publish can succeed.
