### PR TITLE
docs: add AGENTS.md with Cursor Cloud specific setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# js-server-sdk
+
+Fishjam JavaScript/TypeScript server SDK — a Yarn (Berry, v4) workspace.
+
+## Cursor Cloud specific instructions
+
+Node (via nvm) and Corepack/Yarn are pre-installed; the startup script runs `yarn install`. Non-obvious notes:
+
+- Use Corepack-managed Yarn; if `yarn` is not found, run `corepack enable` and ensure the nvm Node bin is on `PATH`.
+- Validated commands: `yarn build`, `yarn typecheck`, `yarn lint:check` (all pass). There is no unit-test script; the SDK is exercised through consuming repos (e.g. `room-manager`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` documenting Cursor Cloud dev-environment setup for this Yarn Berry SDK. No production code changes. Validated: `yarn build`, `yarn typecheck`, `yarn lint:check` all pass; no unit-test script (exercised via consuming repos).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d2d55e2-cb0f-49b0-8d5f-15c80c2982c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d2d55e2-cb0f-49b0-8d5f-15c80c2982c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

