### PR TITLE
Add @fishjam-cloud/composition-cli: build and scaffold composition templates

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        package: [js-server-sdk, composition]
+        package: [js-server-sdk, composition, composition-cli]
 
     permissions:
       contents: read

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -15,6 +15,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            composition-cli:
+              - 'packages/composition-cli/**'
+              - 'package.json'
+              - 'yarn.lock'
+              - '.github/workflows/static.yaml'
+
       - name: Enable corepack
         run: corepack enable
 
@@ -40,9 +51,11 @@ jobs:
         run: yarn typecheck
 
       - name: Unit tests
-        run: |
-          yarn workspace @fishjam-cloud/composition test
-          yarn workspace @fishjam-cloud/composition-cli test
+        run: yarn workspace @fishjam-cloud/composition test
+
+      - name: Composition CLI unit tests
+        if: steps.changes.outputs.composition-cli == 'true'
+        run: yarn workspace @fishjam-cloud/composition-cli test
 
       - name: Check TypeDoc generation
         run: yarn docs

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -39,6 +39,11 @@ jobs:
       - name: Check typing
         run: yarn typecheck
 
+      - name: Unit tests
+        run: |
+          yarn workspace @fishjam-cloud/composition test
+          yarn workspace @fishjam-cloud/composition-cli test
+
       - name: Check TypeDoc generation
         run: yarn docs
 

--- a/packages/composition-cli/LICENSE
+++ b/packages/composition-cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/composition-cli/README.md
+++ b/packages/composition-cli/README.md
@@ -20,9 +20,7 @@ Build the template into an uploadable bundle:
 npm run build
 ```
 
-This compiles `src/App.tsx` into `dist/App.js` and validates it against the platform contract, failing with named reasons for anything the platform would reject: imports outside the allowed set (`react`, `@swmansion/smelter`, `@fishjam-cloud/composition`), `import.meta`, a missing or non-component default export, or exceeding the upload size limit. The bundle is also loaded once with platform packages stubbed to verify it evaluates cleanly, so module-level code in the template runs during the build.
-
-Upload the built bundle as the `template` field when registering a composition output.
+Edit `src/App.tsx` to define your composition layout, then run the build again. The bundle is written to `dist/App.js` — upload it as the `template` field when registering a composition output.
 
 ## License
 

--- a/packages/composition-cli/README.md
+++ b/packages/composition-cli/README.md
@@ -1,0 +1,77 @@
+# @fishjam-cloud/composition-cli
+
+CLI for building [Fishjam](https://fishjam.io) composition template bundles.
+
+A composition template is a React component that defines a video composition layout. The platform runs it server-side and keeps the composition output in sync with the component for the lifetime of the output. This CLI scaffolds template projects and compiles them into the single-file bundle the platform accepts, validating the result locally so upload errors are caught at build time.
+
+## Usage
+
+Scaffold a new template project:
+
+```bash
+npx @fishjam-cloud/composition-cli init my-template
+cd my-template
+npm install
+```
+
+Build the template into an uploadable bundle:
+
+```bash
+npm run build
+```
+
+This compiles `src/App.tsx` into `dist/App.js` and validates it against the platform contract. Upload the bundle as the `template` field when registering a composition output.
+
+## Commands
+
+### `composition-cli init <dir>`
+
+Creates a template project: `package.json` with the supported dependency versions, `tsconfig.json`, and a hello-world `src/App.tsx`.
+
+### `composition-cli build [entry]`
+
+Bundles the template (default entry `src/App.tsx`) and validates the output.
+
+| Option               | Default       | Description                            |
+| -------------------- | ------------- | -------------------------------------- |
+| `-o, --out <file>`   | `dist/App.js` | Output bundle path                     |
+| `--target <version>` | `v1`          | Platform template version to build for |
+
+The build fails (and writes no output) if the bundle violates the platform contract:
+
+- Only these imports may remain external: `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, `@swmansion/smelter`, `@fishjam-cloud/composition`. Everything else is bundled in.
+- No `import.meta` and no dynamic imports with non-literal specifiers.
+- The default export must be a React component.
+- The bundle must fit within the platform upload limit, including headroom for request overhead.
+
+The build also loads the bundle once (with platform-provided packages stubbed out) to verify it evaluates cleanly — module-level code in your template runs during this check.
+
+## Writing templates
+
+Templates default-export a React component built from [`@swmansion/smelter`](https://smelter.dev) components. Room state and events are available through [`@fishjam-cloud/composition`](https://www.npmjs.com/package/@fishjam-cloud/composition) hooks:
+
+```tsx
+import { InputStream, Rescaler, Tiles } from '@swmansion/smelter';
+import { usePeers } from '@fishjam-cloud/composition';
+
+export default function App() {
+  const peers = usePeers();
+  return (
+    <Tiles>
+      {peers.flatMap((peer) =>
+        peer.cameraStream ? (
+          <Rescaler key={peer.cameraStream.inputId}>
+            <InputStream inputId={peer.cameraStream.inputId} />
+          </Rescaler>
+        ) : (
+          []
+        )
+      )}
+    </Tiles>
+  );
+}
+```
+
+## License
+
+Licensed under the [Apache License, Version 2.0](./LICENSE).

--- a/packages/composition-cli/README.md
+++ b/packages/composition-cli/README.md
@@ -1,8 +1,8 @@
+<img src="../../.github/images/fishjam-card.png" width="100%">
+
 # @fishjam-cloud/composition-cli
 
-CLI for building [Fishjam](https://fishjam.io) composition template bundles.
-
-A composition template is a React component that defines a video composition layout. The platform runs it server-side and keeps the composition output in sync with the component for the lifetime of the output. This CLI scaffolds template projects and compiles them into the single-file bundle the platform accepts, validating the result locally so upload errors are caught at build time.
+CLI for scaffolding and building [Fishjam](https://fishjam.io) composition templates.
 
 ## Usage
 
@@ -20,58 +20,16 @@ Build the template into an uploadable bundle:
 npm run build
 ```
 
-This compiles `src/App.tsx` into `dist/App.js` and validates it against the platform contract. Upload the bundle as the `template` field when registering a composition output.
+This compiles `src/App.tsx` into `dist/App.js` and validates it against the platform contract, failing with named reasons for anything the platform would reject: imports outside the allowed set (`react`, `@swmansion/smelter`, `@fishjam-cloud/composition`), `import.meta`, a missing or non-component default export, or exceeding the upload size limit. The bundle is also loaded once with platform packages stubbed to verify it evaluates cleanly, so module-level code in the template runs during the build.
 
-## Commands
-
-### `composition-cli init <dir>`
-
-Creates a template project: `package.json` with the supported dependency versions, `tsconfig.json`, and a hello-world `src/App.tsx`.
-
-### `composition-cli build [entry]`
-
-Bundles the template (default entry `src/App.tsx`) and validates the output.
-
-| Option               | Default       | Description                            |
-| -------------------- | ------------- | -------------------------------------- |
-| `-o, --out <file>`   | `dist/App.js` | Output bundle path                     |
-| `--target <version>` | `v1`          | Platform template version to build for |
-
-The build fails (and writes no output) if the bundle violates the platform contract:
-
-- Only these imports may remain external: `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`, `@swmansion/smelter`, `@fishjam-cloud/composition`. Everything else is bundled in.
-- No `import.meta` and no dynamic imports with non-literal specifiers.
-- The default export must be a React component.
-- The bundle must fit within the platform upload limit, including headroom for request overhead.
-
-The build also loads the bundle once (with platform-provided packages stubbed out) to verify it evaluates cleanly — module-level code in your template runs during this check.
-
-## Writing templates
-
-Templates default-export a React component built from [`@swmansion/smelter`](https://smelter.dev) components. Room state and events are available through [`@fishjam-cloud/composition`](https://www.npmjs.com/package/@fishjam-cloud/composition) hooks:
-
-```tsx
-import { InputStream, Rescaler, Tiles } from '@swmansion/smelter';
-import { usePeers } from '@fishjam-cloud/composition';
-
-export default function App() {
-  const peers = usePeers();
-  return (
-    <Tiles>
-      {peers.flatMap((peer) =>
-        peer.cameraStream ? (
-          <Rescaler key={peer.cameraStream.inputId}>
-            <InputStream inputId={peer.cameraStream.inputId} />
-          </Rescaler>
-        ) : (
-          []
-        )
-      )}
-    </Tiles>
-  );
-}
-```
+Upload the built bundle as the `template` field when registering a composition output.
 
 ## License
 
 Licensed under the [Apache License, Version 2.0](./LICENSE).
+
+## Fishjam is created by Software Mansion
+
+Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues. We can help you build your next dream product – [Hire us](https://swmansion.com/contact/projects?utm_source=fishjam&utm_medium=js-server-readme).
+
+[![Software Mansion](https://logo.swmansion.com/logo?color=white&variant=desktop&width=200&tag=react-client)](https://swmansion.com/contact/projects?utm_source=fishjam&utm_medium=js-server-readme)

--- a/packages/composition-cli/eslint.config.mjs
+++ b/packages/composition-cli/eslint.config.mjs
@@ -1,0 +1,26 @@
+import pluginJs from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default [
+  {
+    ignores: ['dist/**'],
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+  { languageOptions: { globals: { globalThis: 'readonly', console: 'readonly' } } },
+  pluginJs.configs.recommended,
+  ...tseslint.configs.recommended,
+];

--- a/packages/composition-cli/package.json
+++ b/packages/composition-cli/package.json
@@ -42,11 +42,13 @@
   },
   "dependencies": {
     "commander": "^15.0.0",
-    "es-module-lexer": "^2.3.0",
-    "esbuild": "^0.28.1"
+    "es-module-lexer": "^1.5.0",
+    "esbuild": "^0.28.1",
+    "react-is": "^18.3.1"
   },
   "devDependencies": {
     "@types/node": "^22",
+    "@types/react-is": "^18.3.0",
     "eslint": "^9.33.0",
     "prettier": "^3.6.2",
     "tsup": "^8.5.1",

--- a/packages/composition-cli/package.json
+++ b/packages/composition-cli/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@fishjam-cloud/composition-cli",
+  "version": "0.29.0-rc.2",
+  "description": "Utilites to build, validate composition React code",
+  "homepage": "https://github.com/fishjam-cloud/js-server-sdk",
+  "author": "Fishjam Team",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fishjam-cloud/js-server-sdk.git"
+  },
+  "bugs": {
+    "url": "https://github.com/fishjam-cloud/js-server-sdk/issues"
+  },
+  "bin": "./dist/index.mjs",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint . --fix",
+    "lint:check": "eslint .",
+    "test": "vitest run"
+  },
+  "tsup": {
+    "entry": [
+      "src/index.ts"
+    ],
+    "format": [
+      "esm"
+    ],
+    "outDir": "dist",
+    "clean": true
+  },
+  "dependencies": {
+    "commander": "^15.0.0",
+    "es-module-lexer": "^2.3.0",
+    "esbuild": "^0.28.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22",
+    "eslint": "^9.33.0",
+    "prettier": "^3.6.2",
+    "tsup": "^8.5.1",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/composition-cli/package.json
+++ b/packages/composition-cli/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@fishjam-cloud/composition-cli",
   "version": "0.29.0-rc.2",
-  "description": "Utilites to build, validate composition React code",
+  "description": "CLI for scaffolding and building Fishjam composition templates",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/fishjam-cloud/js-server-sdk",
   "author": "Fishjam Team",
   "repository": {

--- a/packages/composition-cli/src/build.ts
+++ b/packages/composition-cli/src/build.ts
@@ -47,7 +47,7 @@ export async function buildTemplate(entry: string, outfile: string, manifest: Ma
   const violations = await validateBundle(bundle.text, manifest);
 
   const bytes = bundle.contents.byteLength;
-  const maxBundleBytes = manifest.maxUploadBytes - UPLOAD_OVERHEAD_RESERVE_BYTES;
+  const maxBundleBytes = Math.max(0, manifest.maxUploadBytes - UPLOAD_OVERHEAD_RESERVE_BYTES);
   if (bytes > maxBundleBytes) {
     violations.push(
       `bundle is ${bytes} bytes; the upload limit is ${manifest.maxUploadBytes} bytes and ${UPLOAD_OVERHEAD_RESERVE_BYTES} bytes are reserved for registration config and multipart overhead, so bundles must stay under ${maxBundleBytes} bytes`

--- a/packages/composition-cli/src/build.ts
+++ b/packages/composition-cli/src/build.ts
@@ -1,0 +1,45 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { build } from 'esbuild';
+import type { Manifest } from './manifests';
+import { validateBundle } from './validate';
+
+export class ValidationError extends Error {
+  readonly violations: string[];
+
+  constructor(violations: string[]) {
+    super(violations.join('\n'));
+    this.name = 'ValidationError';
+    this.violations = violations;
+  }
+}
+
+export async function buildTemplate(entry: string, outfile: string, manifest: Manifest): Promise<{ bytes: number }> {
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    write: false,
+    format: manifest.build.format,
+    target: manifest.build.target,
+    jsx: manifest.build.jsx,
+    jsxImportSource: manifest.build.jsxImportSource,
+    external: [...manifest.allowedImports],
+    logLevel: 'warning',
+  });
+
+  const bundle = result.outputFiles[0];
+  const violations = await validateBundle(bundle.text, manifest);
+
+  const bytes = bundle.contents.byteLength;
+  if (bytes > manifest.maxBundleBytes) {
+    violations.push(`bundle is ${bytes} bytes, which exceeds the ${manifest.maxBundleBytes} byte upload limit`);
+  }
+
+  if (violations.length > 0) {
+    throw new ValidationError(violations);
+  }
+
+  await mkdir(dirname(outfile), { recursive: true });
+  await writeFile(outfile, bundle.contents);
+  return { bytes };
+}

--- a/packages/composition-cli/src/build.ts
+++ b/packages/composition-cli/src/build.ts
@@ -5,8 +5,6 @@ import type { Manifest } from './manifests';
 import { smokeLoadBundle } from './smoke';
 import { validateBundle } from './validate';
 
-const UPLOAD_OVERHEAD_RESERVE_BYTES = 50_000;
-
 export class ValidationError extends Error {
   readonly violations: string[];
 
@@ -47,10 +45,10 @@ export async function buildTemplate(entry: string, outfile: string, manifest: Ma
   const violations = await validateBundle(bundle.text, manifest);
 
   const bytes = bundle.contents.byteLength;
-  const maxBundleBytes = Math.max(0, manifest.maxUploadBytes - UPLOAD_OVERHEAD_RESERVE_BYTES);
+  const maxBundleBytes = Math.max(0, manifest.maxUploadBytes - manifest.uploadOverheadReserveBytes);
   if (bytes > maxBundleBytes) {
     violations.push(
-      `bundle is ${bytes} bytes; the upload limit is ${manifest.maxUploadBytes} bytes and ${UPLOAD_OVERHEAD_RESERVE_BYTES} bytes are reserved for registration config and multipart overhead, so bundles must stay under ${maxBundleBytes} bytes`
+      `bundle is ${bytes} bytes; the upload limit is ${manifest.maxUploadBytes} bytes and ${manifest.uploadOverheadReserveBytes} bytes are reserved for registration config and multipart overhead, so bundles must stay under ${maxBundleBytes} bytes`
     );
   }
 

--- a/packages/composition-cli/src/build.ts
+++ b/packages/composition-cli/src/build.ts
@@ -1,8 +1,11 @@
 import { mkdir, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
-import { build } from 'esbuild';
+import { basename, dirname } from 'node:path';
+import { build, formatMessages } from 'esbuild';
 import type { Manifest } from './manifests';
+import { smokeLoadBundle } from './smoke';
 import { validateBundle } from './validate';
+
+const UPLOAD_OVERHEAD_RESERVE_BYTES = 50_000;
 
 export class ValidationError extends Error {
   readonly violations: string[];
@@ -24,15 +27,35 @@ export async function buildTemplate(entry: string, outfile: string, manifest: Ma
     jsx: manifest.build.jsx,
     jsxImportSource: manifest.build.jsxImportSource,
     external: [...manifest.allowedImports],
-    logLevel: 'warning',
+    outfile,
+    logLevel: 'silent',
   });
+
+  if (result.warnings.length > 0) {
+    const formatted = await formatMessages(result.warnings, { kind: 'warning', color: true });
+    console.error(formatted.join(''));
+  }
+
+  if (result.outputFiles.length !== 1) {
+    const names = result.outputFiles.map((file) => basename(file.path)).join(', ');
+    throw new ValidationError([
+      `build emitted ${result.outputFiles.length} output files (${names}); templates must produce a single JS bundle`,
+    ]);
+  }
 
   const bundle = result.outputFiles[0];
   const violations = await validateBundle(bundle.text, manifest);
 
   const bytes = bundle.contents.byteLength;
-  if (bytes > manifest.maxBundleBytes) {
-    violations.push(`bundle is ${bytes} bytes, which exceeds the ${manifest.maxBundleBytes} byte upload limit`);
+  const maxBundleBytes = manifest.maxUploadBytes - UPLOAD_OVERHEAD_RESERVE_BYTES;
+  if (bytes > maxBundleBytes) {
+    violations.push(
+      `bundle is ${bytes} bytes; the upload limit is ${manifest.maxUploadBytes} bytes and ${UPLOAD_OVERHEAD_RESERVE_BYTES} bytes are reserved for registration config and multipart overhead, so bundles must stay under ${maxBundleBytes} bytes`
+    );
+  }
+
+  if (violations.length === 0) {
+    violations.push(...(await smokeLoadBundle(bundle.text, manifest)));
   }
 
   if (violations.length > 0) {

--- a/packages/composition-cli/src/index.ts
+++ b/packages/composition-cli/src/index.ts
@@ -1,2 +1,58 @@
 #!/usr/bin/env node
-console.log('composition-cli: hello')
+import { Command } from 'commander';
+import pkg from '../package.json';
+import { ValidationError, buildTemplate } from './build';
+import { scaffoldTemplate } from './init';
+import { DEFAULT_TARGET, getManifest } from './manifests';
+
+const program = new Command();
+
+program.name('composition-cli').description('Build and scaffold Fishjam composition templates').version(pkg.version);
+
+program
+  .command('build')
+  .description('Bundle a template and validate it against the platform contract')
+  .argument('[entry]', 'template entry file', 'src/App.tsx')
+  .option('-o, --out <file>', 'output bundle path', 'dist/App.js')
+  .option('--target <version>', 'platform template version to build for', DEFAULT_TARGET)
+  .action(async (entry: string, options: { out: string; target: string }) => {
+    try {
+      const manifest = getManifest(options.target);
+      const { bytes } = await buildTemplate(entry, options.out, manifest);
+      console.log(`${options.out} (${bytes} bytes, target ${manifest.version})`);
+    } catch (err) {
+      fail(err);
+    }
+  });
+
+program
+  .command('init')
+  .description('Scaffold a new template project')
+  .argument('<dir>', 'directory to create the template project in')
+  .option('--target <version>', 'platform template version to build for', DEFAULT_TARGET)
+  .action(async (dir: string, options: { target: string }) => {
+    try {
+      const manifest = getManifest(options.target);
+      const files = await scaffoldTemplate(dir, manifest, pkg.version);
+      for (const file of files) {
+        console.log(`created ${file}`);
+      }
+      console.log(`\nNext steps:\n  cd ${dir}\n  npm install\n  npm run build`);
+    } catch (err) {
+      fail(err);
+    }
+  });
+
+function fail(err: unknown): void {
+  if (err instanceof ValidationError) {
+    console.error('Bundle failed validation:');
+    for (const violation of err.violations) {
+      console.error(`  - ${violation}`);
+    }
+  } else {
+    console.error(err instanceof Error ? err.message : String(err));
+  }
+  process.exitCode = 1;
+}
+
+await program.parseAsync(process.argv);

--- a/packages/composition-cli/src/index.ts
+++ b/packages/composition-cli/src/index.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log('composition-cli: hello')

--- a/packages/composition-cli/src/index.ts
+++ b/packages/composition-cli/src/index.ts
@@ -56,3 +56,4 @@ function fail(err: unknown): void {
 }
 
 await program.parseAsync(process.argv);
+process.exit(process.exitCode ?? 0);

--- a/packages/composition-cli/src/init.ts
+++ b/packages/composition-cli/src/init.ts
@@ -1,0 +1,80 @@
+import { mkdir, readdir, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import type { Manifest } from './manifests';
+
+const scaffoldTsconfig = {
+  compilerOptions: {
+    target: 'ESNext',
+    module: 'ESNext',
+    moduleResolution: 'Bundler',
+    jsx: 'react-jsx',
+    strict: true,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    noEmit: true,
+  },
+  include: ['src'],
+};
+
+const scaffoldApp = `import { Text, View } from '@swmansion/smelter';
+
+export default function App() {
+  return (
+    <View style={{ backgroundColor: '#0b1020ff' }}>
+      <Text style={{ fontSize: 64, color: '#ffffff' }}>Hello from composition-cli</Text>
+    </View>
+  );
+}
+`;
+
+const scaffoldGitignore = `node_modules/
+dist/
+`;
+
+export async function scaffoldTemplate(dir: string, manifest: Manifest, cliVersion: string): Promise<string[]> {
+  await ensureEmpty(dir);
+
+  const pkg = {
+    name: basename(dir),
+    version: '0.0.1',
+    private: true,
+    type: 'module',
+    scripts: {
+      build: 'composition-cli build',
+      typecheck: 'tsc --noEmit',
+    },
+    devDependencies: sortKeys({
+      ...manifest.scaffoldDevDependencies,
+      '@fishjam-cloud/composition-cli': cliVersion,
+    }),
+  };
+
+  const files: Array<[string, string]> = [
+    ['package.json', `${JSON.stringify(pkg, null, 2)}\n`],
+    ['tsconfig.json', `${JSON.stringify(scaffoldTsconfig, null, 2)}\n`],
+    ['.gitignore', scaffoldGitignore],
+    [join('src', 'App.tsx'), scaffoldApp],
+  ];
+
+  await mkdir(join(dir, 'src'), { recursive: true });
+  for (const [name, content] of files) {
+    await writeFile(join(dir, name), content);
+  }
+  return files.map(([name]) => join(dir, name));
+}
+
+async function ensureEmpty(dir: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return;
+  }
+  if (entries.length > 0) {
+    throw new Error(`directory ${dir} is not empty`);
+  }
+}
+
+function sortKeys(record: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => a.localeCompare(b)));
+}

--- a/packages/composition-cli/src/init.ts
+++ b/packages/composition-cli/src/init.ts
@@ -35,7 +35,7 @@ export async function scaffoldTemplate(dir: string, manifest: Manifest, cliVersi
   await ensureEmpty(dir);
 
   const pkg = {
-    name: basename(dir),
+    name: packageNameFrom(dir),
     version: '0.0.1',
     private: true,
     type: 'module',
@@ -67,12 +67,23 @@ async function ensureEmpty(dir: string): Promise<void> {
   let entries: string[];
   try {
     entries = await readdir(dir);
-  } catch {
-    return;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return;
+    }
+    throw err;
   }
   if (entries.length > 0) {
     throw new Error(`directory ${dir} is not empty`);
   }
+}
+
+function packageNameFrom(dir: string): string {
+  const name = basename(dir)
+    .toLowerCase()
+    .replace(/[^a-z0-9-._~]/g, '-')
+    .replace(/^[-._]+/, '');
+  return name.length > 0 ? name : 'composition-template';
 }
 
 function sortKeys(record: Record<string, string>): Record<string, string> {

--- a/packages/composition-cli/src/manifests/index.ts
+++ b/packages/composition-cli/src/manifests/index.ts
@@ -1,0 +1,17 @@
+import type { Manifest } from './types';
+import { v1 } from './v1';
+
+export type { Manifest } from './types';
+
+const manifests: Record<string, Manifest> = { v1 };
+
+export const DEFAULT_TARGET = 'v1';
+
+export function getManifest(target: string): Manifest {
+  const manifest = manifests[target];
+  if (!manifest) {
+    const available = Object.keys(manifests).join(', ');
+    throw new Error(`Unknown target "${target}". Available targets: ${available}`);
+  }
+  return manifest;
+}

--- a/packages/composition-cli/src/manifests/types.ts
+++ b/packages/composition-cli/src/manifests/types.ts
@@ -1,0 +1,12 @@
+export interface Manifest {
+  version: string;
+  allowedImports: string[];
+  maxBundleBytes: number;
+  build: {
+    format: 'esm';
+    target: string;
+    jsx: 'automatic';
+    jsxImportSource: string;
+  };
+  scaffoldDevDependencies: Record<string, string>;
+}

--- a/packages/composition-cli/src/manifests/types.ts
+++ b/packages/composition-cli/src/manifests/types.ts
@@ -2,6 +2,7 @@ export interface Manifest {
   version: string;
   allowedImports: string[];
   maxUploadBytes: number;
+  uploadOverheadReserveBytes: number;
   build: {
     format: 'esm';
     target: string;

--- a/packages/composition-cli/src/manifests/types.ts
+++ b/packages/composition-cli/src/manifests/types.ts
@@ -1,7 +1,7 @@
 export interface Manifest {
   version: string;
   allowedImports: string[];
-  maxBundleBytes: number;
+  maxUploadBytes: number;
   build: {
     format: 'esm';
     target: string;

--- a/packages/composition-cli/src/manifests/v1.ts
+++ b/packages/composition-cli/src/manifests/v1.ts
@@ -10,6 +10,7 @@ export const v1: Manifest = {
     '@fishjam-cloud/composition',
   ],
   maxUploadBytes: 1_000_000,
+  uploadOverheadReserveBytes: 50_000,
   build: {
     format: 'esm',
     target: 'esnext',

--- a/packages/composition-cli/src/manifests/v1.ts
+++ b/packages/composition-cli/src/manifests/v1.ts
@@ -9,7 +9,7 @@ export const v1: Manifest = {
     '@swmansion/smelter',
     '@fishjam-cloud/composition',
   ],
-  maxBundleBytes: 1_000_000,
+  maxUploadBytes: 1_000_000,
   build: {
     format: 'esm',
     target: 'esnext',

--- a/packages/composition-cli/src/manifests/v1.ts
+++ b/packages/composition-cli/src/manifests/v1.ts
@@ -1,0 +1,26 @@
+import type { Manifest } from './types';
+
+export const v1: Manifest = {
+  version: 'v1',
+  allowedImports: [
+    'react',
+    'react/jsx-runtime',
+    'react/jsx-dev-runtime',
+    '@swmansion/smelter',
+    '@fishjam-cloud/composition',
+  ],
+  maxBundleBytes: 1_000_000,
+  build: {
+    format: 'esm',
+    target: 'esnext',
+    jsx: 'automatic',
+    jsxImportSource: 'react',
+  },
+  scaffoldDevDependencies: {
+    '@fishjam-cloud/composition': '0.29.0-rc.2',
+    '@swmansion/smelter': '0.3.0',
+    '@types/react': '^18.3.0',
+    react: '^18.3.1',
+    typescript: '^5.6.0',
+  },
+};

--- a/packages/composition-cli/src/smoke.ts
+++ b/packages/composition-cli/src/smoke.ts
@@ -1,25 +1,52 @@
+import { fileURLToPath } from 'node:url';
+import { Worker } from 'node:worker_threads';
 import { build } from 'esbuild';
-import { isValidElementType } from 'react-is';
 import type { Manifest } from './manifests';
+
+const DEFAULT_LOAD_TIMEOUT_MS = 5_000;
 
 const stubModule = 'module.exports = new Proxy(function stub() {}, { get: () => () => null });';
 
-export async function smokeLoadBundle(source: string, manifest: Manifest): Promise<string[]> {
+const workerEntry = `
+import { parentPort } from 'node:worker_threads';
+import { isValidElementType } from 'react-is';
+import * as template from 'composition-template';
+parentPort.postMessage(isValidElementType(template.default));
+`;
+
+export async function smokeLoadBundle(
+  source: string,
+  manifest: Manifest,
+  timeoutMs: number = DEFAULT_LOAD_TIMEOUT_MS
+): Promise<string[]> {
   const escaped = manifest.allowedImports.map((spec) => spec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
   const allowedFilter = new RegExp(`^(${escaped.join('|')})$`);
 
   let result;
   try {
     result = await build({
-      stdin: { contents: source, loader: 'js' },
+      stdin: {
+        contents: workerEntry,
+        loader: 'js',
+        resolveDir: fileURLToPath(new URL('.', import.meta.url)),
+      },
       bundle: true,
       write: false,
       format: 'esm',
+      platform: 'node',
       logLevel: 'silent',
       plugins: [
         {
-          name: 'stub-allowed-imports',
+          name: 'smoke-modules',
           setup(builder) {
+            builder.onResolve({ filter: /^composition-template$/ }, (args) => ({
+              path: args.path,
+              namespace: 'template',
+            }));
+            builder.onLoad({ filter: /.*/, namespace: 'template' }, () => ({
+              contents: source,
+              loader: 'js',
+            }));
             builder.onResolve({ filter: allowedFilter }, (args) => ({
               path: args.path,
               namespace: 'stub',
@@ -38,16 +65,28 @@ export async function smokeLoadBundle(source: string, manifest: Manifest): Promi
   }
 
   const encoded = Buffer.from(result.outputFiles[0].contents).toString('base64');
-  let mod: { default?: unknown };
-  try {
-    mod = (await import(`data:text/javascript;base64,${encoded}`)) as { default?: unknown };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return [`bundle threw while loading: ${message}`];
-  }
+  return loadInWorker(new URL(`data:text/javascript;base64,${encoded}`), timeoutMs);
+}
 
-  if (!isValidElementType(mod.default)) {
-    return ['default export is not a React component'];
-  }
-  return [];
+function loadInWorker(bundleUrl: URL, timeoutMs: number): Promise<string[]> {
+  return new Promise((resolve) => {
+    const worker = new Worker(bundleUrl);
+    const finish = (violations: string[]) => {
+      clearTimeout(timer);
+      void worker.terminate();
+      resolve(violations);
+    };
+    const timer = setTimeout(() => {
+      finish([`bundle did not finish loading within ${timeoutMs}ms; top-level code must not block the event loop`]);
+    }, timeoutMs);
+    worker.once('message', (isComponent: unknown) => {
+      finish(isComponent ? [] : ['default export is not a React component']);
+    });
+    worker.once('error', (err) => {
+      finish([`bundle threw while loading: ${err.message}`]);
+    });
+    worker.once('exit', () => {
+      finish(['bundle exited before the smoke check completed']);
+    });
+  });
 }

--- a/packages/composition-cli/src/smoke.ts
+++ b/packages/composition-cli/src/smoke.ts
@@ -8,28 +8,34 @@ export async function smokeLoadBundle(source: string, manifest: Manifest): Promi
   const escaped = manifest.allowedImports.map((spec) => spec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
   const allowedFilter = new RegExp(`^(${escaped.join('|')})$`);
 
-  const result = await build({
-    stdin: { contents: source, loader: 'js' },
-    bundle: true,
-    write: false,
-    format: 'esm',
-    logLevel: 'silent',
-    plugins: [
-      {
-        name: 'stub-allowed-imports',
-        setup(builder) {
-          builder.onResolve({ filter: allowedFilter }, (args) => ({
-            path: args.path,
-            namespace: 'stub',
-          }));
-          builder.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({
-            contents: stubModule,
-            loader: 'js',
-          }));
+  let result;
+  try {
+    result = await build({
+      stdin: { contents: source, loader: 'js' },
+      bundle: true,
+      write: false,
+      format: 'esm',
+      logLevel: 'silent',
+      plugins: [
+        {
+          name: 'stub-allowed-imports',
+          setup(builder) {
+            builder.onResolve({ filter: allowedFilter }, (args) => ({
+              path: args.path,
+              namespace: 'stub',
+            }));
+            builder.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({
+              contents: stubModule,
+              loader: 'js',
+            }));
+          },
         },
-      },
-    ],
-  });
+      ],
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return [`bundle could not be prepared for loading: ${message}`];
+  }
 
   const encoded = Buffer.from(result.outputFiles[0].contents).toString('base64');
   let mod: { default?: unknown };

--- a/packages/composition-cli/src/smoke.ts
+++ b/packages/composition-cli/src/smoke.ts
@@ -1,0 +1,47 @@
+import { build } from 'esbuild';
+import { isValidElementType } from 'react-is';
+import type { Manifest } from './manifests';
+
+const stubModule = 'module.exports = new Proxy(function stub() {}, { get: () => () => null });';
+
+export async function smokeLoadBundle(source: string, manifest: Manifest): Promise<string[]> {
+  const escaped = manifest.allowedImports.map((spec) => spec.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const allowedFilter = new RegExp(`^(${escaped.join('|')})$`);
+
+  const result = await build({
+    stdin: { contents: source, loader: 'js' },
+    bundle: true,
+    write: false,
+    format: 'esm',
+    logLevel: 'silent',
+    plugins: [
+      {
+        name: 'stub-allowed-imports',
+        setup(builder) {
+          builder.onResolve({ filter: allowedFilter }, (args) => ({
+            path: args.path,
+            namespace: 'stub',
+          }));
+          builder.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({
+            contents: stubModule,
+            loader: 'js',
+          }));
+        },
+      },
+    ],
+  });
+
+  const encoded = Buffer.from(result.outputFiles[0].contents).toString('base64');
+  let mod: { default?: unknown };
+  try {
+    mod = (await import(`data:text/javascript;base64,${encoded}`)) as { default?: unknown };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return [`bundle threw while loading: ${message}`];
+  }
+
+  if (!isValidElementType(mod.default)) {
+    return ['default export is not a React component'];
+  }
+  return [];
+}

--- a/packages/composition-cli/src/validate.ts
+++ b/packages/composition-cli/src/validate.ts
@@ -1,0 +1,40 @@
+import { init, parse } from 'es-module-lexer';
+import type { Manifest } from './manifests';
+
+export async function validateBundle(source: string, manifest: Manifest): Promise<string[]> {
+  await init;
+
+  let imports;
+  let exports;
+  try {
+    [imports, exports] = parse(source);
+  } catch {
+    return ['bundle is not valid JavaScript (ESM)'];
+  }
+
+  const allowed = new Set(manifest.allowedImports);
+  const violations: string[] = [];
+
+  for (const imp of imports) {
+    const line = lineOf(source, imp.ss);
+    if (imp.d === -2) {
+      violations.push(`import.meta is not allowed (line ${line})`);
+    } else if (imp.n === undefined) {
+      violations.push(`dynamic import with a non-literal specifier is not allowed (line ${line})`);
+    } else if (!allowed.has(imp.n)) {
+      violations.push(
+        `import of "${imp.n}" is not allowed (line ${line}); allowed imports: ${manifest.allowedImports.join(', ')}`
+      );
+    }
+  }
+
+  if (!exports.some((exp) => exp.n === 'default')) {
+    violations.push('bundle has no default export; templates must default-export a React component');
+  }
+
+  return violations;
+}
+
+function lineOf(source: string, offset: number): number {
+  return source.slice(0, offset).split('\n').length;
+}

--- a/packages/composition-cli/src/validate.ts
+++ b/packages/composition-cli/src/validate.ts
@@ -13,17 +13,17 @@ export async function validateBundle(source: string, manifest: Manifest): Promis
   }
 
   const allowed = new Set(manifest.allowedImports);
+  const allowedList = manifest.allowedImports.join(', ');
   const violations: string[] = [];
 
   for (const imp of imports) {
-    const line = lineOf(source, imp.ss);
     if (imp.d === -2) {
-      violations.push(`import.meta is not allowed (line ${line})`);
+      violations.push(`import.meta is not allowed (line ${lineOf(source, imp.ss)})`);
     } else if (imp.n === undefined) {
-      violations.push(`dynamic import with a non-literal specifier is not allowed (line ${line})`);
+      violations.push(`dynamic import with a non-literal specifier is not allowed (line ${lineOf(source, imp.ss)})`);
     } else if (!allowed.has(imp.n)) {
       violations.push(
-        `import of "${imp.n}" is not allowed (line ${line}); allowed imports: ${manifest.allowedImports.join(', ')}`
+        `import of "${imp.n}" is not allowed (line ${lineOf(source, imp.ss)}); allowed imports: ${allowedList}`
       );
     }
   }

--- a/packages/composition-cli/src/validate.ts
+++ b/packages/composition-cli/src/validate.ts
@@ -1,11 +1,11 @@
-import { init, parse } from 'es-module-lexer';
+import { type ExportSpecifier, type ImportSpecifier, init, parse } from 'es-module-lexer';
 import type { Manifest } from './manifests';
 
 export async function validateBundle(source: string, manifest: Manifest): Promise<string[]> {
   await init;
 
-  let imports;
-  let exports;
+  let imports: readonly ImportSpecifier[];
+  let exports: readonly ExportSpecifier[];
   try {
     [imports, exports] = parse(source);
   } catch {

--- a/packages/composition-cli/tests/build.test.ts
+++ b/packages/composition-cli/tests/build.test.ts
@@ -67,15 +67,64 @@ describe('buildTemplate', () => {
   });
 
   it('rejects a bundle exceeding the size limit', async () => {
-    const tinyManifest = { ...manifest, maxBundleBytes: 16 };
+    const tinyManifest = { ...manifest, maxUploadBytes: 16 };
 
     await expect(buildTemplate(join(dir, 'src', 'App.tsx'), join(dir, 'dist', 'App.js'), tinyManifest)).rejects.toThrow(
       /16/
     );
   });
 
+  it('reserves headroom for multipart upload overhead', async () => {
+    const nearLimitManifest = { ...manifest, maxUploadBytes: 50_016 };
+
+    await expect(
+      buildTemplate(join(dir, 'src', 'App.tsx'), join(dir, 'dist', 'App.js'), nearLimitManifest)
+    ).rejects.toThrow(/overhead|upload/i);
+  });
+
+  it('rejects a build that emits more than one output file', async () => {
+    await writeFile(join(dir, 'src', 'styles.css'), '.x { color: red; }\n');
+    await writeFile(
+      join(dir, 'src', 'App.tsx'),
+      `import './styles.css';\nexport default function App() {\n  return null;\n}\n`
+    );
+
+    await expect(buildTemplate(join(dir, 'src', 'App.tsx'), join(dir, 'dist', 'App.js'), manifest)).rejects.toThrow(
+      /single/i
+    );
+  });
+
+  it('rejects a bundle whose default export is not a React component', async () => {
+    await writeFile(join(dir, 'src', 'App.tsx'), `const answer = 42;\nexport default answer;\n`);
+
+    await expect(buildTemplate(join(dir, 'src', 'App.tsx'), join(dir, 'dist', 'App.js'), manifest)).rejects.toThrow(
+      /React component/
+    );
+  });
+
+  it('rejects a bundle that throws while loading', async () => {
+    await writeFile(
+      join(dir, 'src', 'App.tsx'),
+      `if (globalThis) {\n  throw new Error('boom');\n}\nexport default function App() {\n  return null;\n}\n`
+    );
+
+    await expect(buildTemplate(join(dir, 'src', 'App.tsx'), join(dir, 'dist', 'App.js'), manifest)).rejects.toThrow(
+      /loading/
+    );
+  });
+
+  it('accepts a component that uses allowed imports at module top level', async () => {
+    await writeFile(
+      join(dir, 'src', 'App.tsx'),
+      `import { useState } from 'react';\nimport { View } from '@swmansion/smelter';\n\nexport default function App() {\n  const [on] = useState(false);\n  return on ? <View /> : null;\n}\n`
+    );
+
+    const { bytes } = await buildTemplate(join(dir, 'src', 'App.tsx'), join(dir, 'dist', 'App.js'), manifest);
+    expect(bytes).toBeGreaterThan(0);
+  });
+
   it('does not write the outfile when validation fails', async () => {
-    const tinyManifest = { ...manifest, maxBundleBytes: 16 };
+    const tinyManifest = { ...manifest, maxUploadBytes: 16 };
     const outfile = join(dir, 'dist', 'App.js');
 
     await expect(buildTemplate(join(dir, 'src', 'App.tsx'), outfile, tinyManifest)).rejects.toThrow();

--- a/packages/composition-cli/tests/build.test.ts
+++ b/packages/composition-cli/tests/build.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ValidationError, buildTemplate } from '../src/build';
+import { getManifest } from '../src/manifests';
+import { validateBundle } from '../src/validate';
+
+const manifest = getManifest('v1');
+
+const appTsx = `import { Text, View } from '@swmansion/smelter';
+import { formatTitle } from './title';
+
+export default function App() {
+  return (
+    <View>
+      <Text style={{ fontSize: 40 }}>{formatTitle('hello')}</Text>
+    </View>
+  );
+}
+`;
+
+const titleTs = `export function formatTitle(name: string): string {
+  return name.toUpperCase();
+}
+`;
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'composition-cli-test-'));
+  await mkdir(join(dir, 'src'));
+  await writeFile(join(dir, 'src', 'App.tsx'), appTsx);
+  await writeFile(join(dir, 'src', 'title.ts'), titleTs);
+});
+
+describe('buildTemplate', () => {
+  it('produces a single valid ESM bundle with relative imports inlined', async () => {
+    const outfile = join(dir, 'dist', 'App.js');
+    const { bytes } = await buildTemplate(join(dir, 'src', 'App.tsx'), outfile, manifest);
+
+    const output = await readFile(outfile, 'utf8');
+    expect(bytes).toBeGreaterThan(0);
+    expect(output).toContain('toUpperCase');
+    expect(output).not.toContain('./title');
+    expect(await validateBundle(output, manifest)).toEqual([]);
+  });
+
+  it('keeps allowed imports external instead of inlining them', async () => {
+    const outfile = join(dir, 'dist', 'App.js');
+    await buildTemplate(join(dir, 'src', 'App.tsx'), outfile, manifest);
+
+    const output = await readFile(outfile, 'utf8');
+    expect(output).toMatch(/from\s+["']@swmansion\/smelter["']/);
+    expect(output).toMatch(/from\s+["']react\/jsx-runtime["']/);
+  });
+
+  it('rejects a bundle that ends up containing import.meta', async () => {
+    await writeFile(
+      join(dir, 'src', 'App.tsx'),
+      `export default function App() {\n  return <>{import.meta.url}</>;\n}\n`
+    );
+
+    await expect(buildTemplate(join(dir, 'src', 'App.tsx'), join(dir, 'dist', 'App.js'), manifest)).rejects.toThrow(
+      ValidationError
+    );
+  });
+
+  it('rejects a bundle exceeding the size limit', async () => {
+    const tinyManifest = { ...manifest, maxBundleBytes: 16 };
+
+    await expect(buildTemplate(join(dir, 'src', 'App.tsx'), join(dir, 'dist', 'App.js'), tinyManifest)).rejects.toThrow(
+      /16/
+    );
+  });
+
+  it('does not write the outfile when validation fails', async () => {
+    const tinyManifest = { ...manifest, maxBundleBytes: 16 };
+    const outfile = join(dir, 'dist', 'App.js');
+
+    await expect(buildTemplate(join(dir, 'src', 'App.tsx'), outfile, tinyManifest)).rejects.toThrow();
+    await expect(readFile(outfile, 'utf8')).rejects.toThrow();
+  });
+});

--- a/packages/composition-cli/tests/init.test.ts
+++ b/packages/composition-cli/tests/init.test.ts
@@ -39,6 +39,22 @@ describe('scaffoldTemplate', () => {
     expect(gitignore).toContain('dist');
   });
 
+  it('normalizes the directory name into a valid npm package name', async () => {
+    const target = join(dir, 'My Template');
+    await scaffoldTemplate(target, manifest, '1.2.3');
+
+    const pkg = JSON.parse(await readFile(join(target, 'package.json'), 'utf8'));
+    expect(pkg.name).toBe('my-template');
+  });
+
+  it('fails clearly when the target is an existing file', async () => {
+    const target = join(dir, 'occupied.txt');
+    await writeFile(target, 'a file, not a directory');
+
+    await expect(scaffoldTemplate(target, manifest, '1.2.3')).rejects.toThrow();
+    expect(await readFile(target, 'utf8')).toBe('a file, not a directory');
+  });
+
   it('refuses to scaffold into a non-empty directory', async () => {
     const target = join(dir, 'occupied');
     await mkdir(target);

--- a/packages/composition-cli/tests/init.test.ts
+++ b/packages/composition-cli/tests/init.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getManifest } from '../src/manifests';
+import { scaffoldTemplate } from '../src/init';
+
+const manifest = getManifest('v1');
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'composition-cli-init-'));
+});
+
+describe('scaffoldTemplate', () => {
+  it('creates a buildable template project', async () => {
+    const target = join(dir, 'my-template');
+    await scaffoldTemplate(target, manifest, '1.2.3');
+
+    const pkg = JSON.parse(await readFile(join(target, 'package.json'), 'utf8'));
+    expect(pkg.name).toBe('my-template');
+    expect(pkg.private).toBe(true);
+    expect(pkg.type).toBe('module');
+    expect(pkg.scripts.build).toContain('composition-cli build');
+    expect(pkg.devDependencies).toMatchObject(manifest.scaffoldDevDependencies);
+    expect(pkg.devDependencies['@fishjam-cloud/composition-cli']).toBe('1.2.3');
+
+    const tsconfig = JSON.parse(await readFile(join(target, 'tsconfig.json'), 'utf8'));
+    expect(tsconfig.compilerOptions.jsx).toBe('react-jsx');
+    expect(tsconfig.compilerOptions.noEmit).toBe(true);
+
+    const app = await readFile(join(target, 'src', 'App.tsx'), 'utf8');
+    expect(app).toContain('export default function App');
+    expect(app).toContain("from '@swmansion/smelter'");
+
+    const gitignore = await readFile(join(target, '.gitignore'), 'utf8');
+    expect(gitignore).toContain('node_modules');
+    expect(gitignore).toContain('dist');
+  });
+
+  it('refuses to scaffold into a non-empty directory', async () => {
+    const target = join(dir, 'occupied');
+    await mkdir(target);
+    await writeFile(join(target, 'keep.txt'), 'important');
+
+    await expect(scaffoldTemplate(target, manifest, '1.2.3')).rejects.toThrow(/not empty/);
+    expect(await readFile(join(target, 'keep.txt'), 'utf8')).toBe('important');
+  });
+
+  it('scaffolds into an existing empty directory', async () => {
+    const target = join(dir, 'empty');
+    await mkdir(target);
+
+    await scaffoldTemplate(target, manifest, '1.2.3');
+    await readFile(join(target, 'package.json'), 'utf8');
+  });
+});

--- a/packages/composition-cli/tests/smoke.test.ts
+++ b/packages/composition-cli/tests/smoke.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { getManifest } from '../src/manifests';
+import { smokeLoadBundle } from '../src/smoke';
+
+const manifest = getManifest('v1');
+
+describe('smokeLoadBundle', () => {
+  it('accepts a bundle whose default export is a component', async () => {
+    const source = `export default function App() {\n  return null;\n}\n`;
+
+    expect(await smokeLoadBundle(source, manifest)).toEqual([]);
+  });
+
+  it('terminates a bundle that blocks the event loop at top level', async () => {
+    const source = `while (true) {}\nexport default function App() {\n  return null;\n}\n`;
+
+    const violations = await smokeLoadBundle(source, manifest, 1_000);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatch(/did not finish loading/);
+  });
+});

--- a/packages/composition-cli/tests/validate.test.ts
+++ b/packages/composition-cli/tests/validate.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { getManifest } from '../src/manifests';
+import { validateBundle } from '../src/validate';
+
+const manifest = getManifest('v1');
+
+const validBundle = `import { useState } from 'react';
+import { jsx } from 'react/jsx-runtime';
+import { View } from '@swmansion/smelter';
+import { usePeers } from '@fishjam-cloud/composition';
+function App() {
+  const [on] = useState(false);
+  usePeers();
+  return jsx(View, {});
+}
+export { App as default };
+`;
+
+describe('validateBundle', () => {
+  it('accepts a bundle importing only allowed modules', async () => {
+    expect(await validateBundle(validBundle, manifest)).toEqual([]);
+  });
+
+  it('accepts a dynamic import with a literal allowed specifier', async () => {
+    const source = `export default function App() {}\nimport('react');\n`;
+    expect(await validateBundle(source, manifest)).toEqual([]);
+  });
+
+  it('rejects a relative import', async () => {
+    const source = `import { helper } from './helper.js';\nexport default function App() {}\n`;
+    const violations = await validateBundle(source, manifest);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('./helper.js');
+  });
+
+  it('rejects an absolute import', async () => {
+    const source = `import '/etc/passwd';\nexport default function App() {}\n`;
+    expect(await validateBundle(source, manifest)).toHaveLength(1);
+  });
+
+  it('rejects an unlisted bare import', async () => {
+    const source = `import _ from 'lodash';\nexport default function App() {}\n`;
+    const violations = await validateBundle(source, manifest);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('lodash');
+  });
+
+  it('rejects a deep subpath of an allowed package', async () => {
+    const source = `import 'react/cjs/react.development.js';\nexport default function App() {}\n`;
+    expect(await validateBundle(source, manifest)).toHaveLength(1);
+  });
+
+  it('rejects URL-scheme specifiers', async () => {
+    for (const spec of ['npm:react', 'node:fs', 'https://example.com/mod.js', 'data:text/javascript,']) {
+      const source = `import '${spec}';\nexport default function App() {}\n`;
+      expect(await validateBundle(source, manifest), spec).toHaveLength(1);
+    }
+  });
+
+  it('rejects import.meta', async () => {
+    const source = `export default function App() {\n  return import.meta.url;\n}\n`;
+    const violations = await validateBundle(source, manifest);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('import.meta');
+  });
+
+  it('rejects a dynamic import with a non-literal specifier', async () => {
+    const source = `const name = 'react';\nimport(name);\nexport default function App() {}\n`;
+    const violations = await validateBundle(source, manifest);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('dynamic');
+  });
+
+  it('rejects source that is not valid JavaScript', async () => {
+    const violations = await validateBundle('import { from;;;', manifest);
+    expect(violations).toHaveLength(1);
+  });
+
+  it('rejects a bundle without a default export', async () => {
+    const source = `import { View } from '@swmansion/smelter';\nexport function App() {}\n`;
+    const violations = await validateBundle(source, manifest);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toContain('default export');
+  });
+
+  it('collects all violations instead of stopping at the first', async () => {
+    const source = `import _ from 'lodash';\nimport './helper.js';\nexport function App() {}\n`;
+    expect(await validateBundle(source, manifest)).toHaveLength(3);
+  });
+
+  it('reports the line of a violation', async () => {
+    const source = `import { View } from '@swmansion/smelter';\nimport _ from 'lodash';\nexport default function App() {}\n`;
+    const violations = await validateBundle(source, manifest);
+    expect(violations[0]).toContain('line 2');
+  });
+});

--- a/packages/composition-cli/tsconfig.json
+++ b/packages/composition-cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "_version": "20.1.0",
+
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "esnext",
+    "target": "es2022",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "moduleResolution": "bundler",
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"],
+    "outDir": "dist"
+  },
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1752,11 +1752,13 @@ __metadata:
   resolution: "@fishjam-cloud/composition-cli@workspace:packages/composition-cli"
   dependencies:
     "@types/node": "npm:^22"
+    "@types/react-is": "npm:^18.3.0"
     commander: "npm:^15.0.0"
-    es-module-lexer: "npm:^2.3.0"
+    es-module-lexer: "npm:^1.5.0"
     esbuild: "npm:^0.28.1"
     eslint: "npm:^9.33.0"
     prettier: "npm:^3.6.2"
+    react-is: "npm:^18.3.1"
     tsup: "npm:^8.5.1"
     vitest: "npm:^3.0.0"
   bin:
@@ -2809,12 +2811,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:*":
+  version: 15.7.15
+  resolution: "@types/prop-types@npm:15.7.15"
+  checksum: 10c0/b59aad1ad19bf1733cf524fd4e618196c6c7690f48ee70a327eb450a42aab8e8a063fbe59ca0a5701aebe2d92d582292c0fb845ea57474f6a15f6994b0e260b2
+  languageName: node
+  linkType: hard
+
 "@types/react-dom@npm:^19.1.9":
   version: 19.2.1
   resolution: "@types/react-dom@npm:19.2.1"
   peerDependencies:
     "@types/react": ^19.2.0
   checksum: 10c0/0dbbc5b7ecd74681bfac95a413133b26118a70b8840748277abafa47e5c7a037beae6a660e6a21fb53f5cbdb0b2d33e117ea7bbd976a888c298392a8a96bc68f
+  languageName: node
+  linkType: hard
+
+"@types/react-is@npm:^18.3.0":
+  version: 18.3.1
+  resolution: "@types/react-is@npm:18.3.1"
+  dependencies:
+    "@types/react": "npm:^18"
+  checksum: 10c0/c2a13c940c8dabc5fe38554f0b78560411a0618cc9b733c06d884b35f631b5c89eb88a016593df3b5bfd923517a337fd4a2f32598094f8924ac8e22b5f874c99
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18":
+  version: 18.3.31
+  resolution: "@types/react@npm:18.3.31"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.2.2"
+  checksum: 10c0/44180549dd045f536ececd39e39aacdf828e76adc1c4a90b132f453e23cc370c4648d9102ae401172ebd8fd8b1977a901a39e214e53ec77171b27514b588c179
   languageName: node
   linkType: hard
 
@@ -4422,17 +4450,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^1.7.0":
+"es-module-lexer@npm:^1.5.0, es-module-lexer@npm:^1.7.0":
   version: 1.7.0
   resolution: "es-module-lexer@npm:1.7.0"
   checksum: 10c0/4c935affcbfeba7fb4533e1da10fa8568043df1e3574b869385980de9e2d475ddc36769891936dbb07036edb3c3786a8b78ccf44964cd130dedc1f2c984b6c7b
-  languageName: node
-  linkType: hard
-
-"es-module-lexer@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "es-module-lexer@npm:2.3.0"
-  checksum: 10c0/14b28d854ec2aec285c481daeea268451e01ab2813f09f98eb1ac432521d8c3b38ce552a49f2e4af3ba188b74acbafe9e8d7271ce912bd98f1651b02bd06717e
   languageName: node
   linkType: hard
 
@@ -7357,6 +7378,13 @@ __metadata:
   peerDependencies:
     react: ^19.2.0
   checksum: 10c0/fa2cae05248d01288e91523b590ce4e7635b1e13f1344e225f850d722a8da037bf0782f63b1c1d46353334e0c696909b82e582f8cad607948fde6f7646cc18d9
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: 10c0/f2f1e60010c683479e74c63f96b09fb41603527cd131a9959e2aee1e5a8b0caf270b365e5ca77d4a6b18aae659b60a86150bb3979073528877029b35aecd2072
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,6 +814,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/aix-ppc64@npm:0.28.1"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/android-arm64@npm:0.25.0"
@@ -831,6 +838,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/android-arm64@npm:0.27.7"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm64@npm:0.28.1"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -856,6 +870,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-arm@npm:0.28.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-x64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/android-x64@npm:0.25.0"
@@ -873,6 +894,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/android-x64@npm:0.27.7"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/android-x64@npm:0.28.1"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -898,6 +926,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-arm64@npm:0.28.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-x64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/darwin-x64@npm:0.25.0"
@@ -915,6 +950,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/darwin-x64@npm:0.27.7"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/darwin-x64@npm:0.28.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -940,6 +982,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-arm64@npm:0.28.1"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-x64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/freebsd-x64@npm:0.25.0"
@@ -957,6 +1006,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/freebsd-x64@npm:0.27.7"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/freebsd-x64@npm:0.28.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -982,6 +1038,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm64@npm:0.28.1"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/linux-arm@npm:0.25.0"
@@ -999,6 +1062,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/linux-arm@npm:0.27.7"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-arm@npm:0.28.1"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -1024,6 +1094,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ia32@npm:0.28.1"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-loong64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/linux-loong64@npm:0.25.0"
@@ -1041,6 +1118,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/linux-loong64@npm:0.27.7"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-loong64@npm:0.28.1"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -1066,6 +1150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-mips64el@npm:0.28.1"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ppc64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/linux-ppc64@npm:0.25.0"
@@ -1083,6 +1174,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/linux-ppc64@npm:0.27.7"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-ppc64@npm:0.28.1"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -1108,6 +1206,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-riscv64@npm:0.28.1"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/linux-s390x@npm:0.25.0"
@@ -1125,6 +1230,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/linux-s390x@npm:0.27.7"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-s390x@npm:0.28.1"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -1150,6 +1262,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/linux-x64@npm:0.28.1"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-arm64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/netbsd-arm64@npm:0.25.0"
@@ -1167,6 +1286,13 @@ __metadata:
 "@esbuild/netbsd-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-arm64@npm:0.28.1"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1192,6 +1318,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/netbsd-x64@npm:0.28.1"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-arm64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/openbsd-arm64@npm:0.25.0"
@@ -1209,6 +1342,13 @@ __metadata:
 "@esbuild/openbsd-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-arm64@npm:0.28.1"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
@@ -1234,9 +1374,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openbsd-x64@npm:0.28.1"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openharmony-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/openharmony-arm64@npm:0.28.1"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -1262,6 +1416,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/sunos-x64@npm:0.28.1"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/win32-arm64@npm:0.25.0"
@@ -1279,6 +1440,13 @@ __metadata:
 "@esbuild/win32-arm64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/win32-arm64@npm:0.27.7"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-arm64@npm:0.28.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -1304,6 +1472,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-ia32@npm:0.28.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-x64@npm:0.25.0":
   version: 0.25.0
   resolution: "@esbuild/win32-x64@npm:0.25.0"
@@ -1321,6 +1496,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.27.7":
   version: 0.27.7
   resolution: "@esbuild/win32-x64@npm:0.27.7"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.28.1":
+  version: 0.28.1
+  resolution: "@esbuild/win32-x64@npm:0.28.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1564,6 +1746,23 @@ __metadata:
   checksum: 10c0/bbf836fa09d1035d033b494e7c9aa88a69a2b1415eb6e4f706c2833be8b89e994ee4fd900fef1a08937382d77f5a04dae2f7380a94e5a9d847002efb26911883
   languageName: node
   linkType: hard
+
+"@fishjam-cloud/composition-cli@workspace:packages/composition-cli":
+  version: 0.0.0-use.local
+  resolution: "@fishjam-cloud/composition-cli@workspace:packages/composition-cli"
+  dependencies:
+    "@types/node": "npm:^22"
+    commander: "npm:^15.0.0"
+    es-module-lexer: "npm:^2.3.0"
+    esbuild: "npm:^0.28.1"
+    eslint: "npm:^9.33.0"
+    prettier: "npm:^3.6.2"
+    tsup: "npm:^8.5.1"
+    vitest: "npm:^3.0.0"
+  bin:
+    composition-cli: ./dist/index.mjs
+  languageName: unknown
+  linkType: soft
 
 "@fishjam-cloud/composition@workspace:packages/composition":
   version: 0.0.0-use.local
@@ -2592,6 +2791,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node@npm:^22":
+  version: 22.20.0
+  resolution: "@types/node@npm:22.20.0"
+  dependencies:
+    undici-types: "npm:~6.21.0"
+  checksum: 10c0/55d78223205bd5f81f043d71b7a5c8d8854b9ef44ef81291680943adb27fa5ba1f092658c87183d5bc8cf6baf6a57b81dad966eb3afa452cc301a615b6d9b20e
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^22.13.16":
   version: 22.13.16
   resolution: "@types/node@npm:22.13.16"
@@ -2911,6 +3119,15 @@ __metadata:
   bin:
     acorn: bin/acorn
   checksum: 10c0/dec73ff59b7d6628a01eebaece7f2bdb8bb62b9b5926dcad0f8931f2b8b79c2be21f6c68ac095592adb5adb15831a3635d9343e6a91d028bbe85d564875ec3ec
+  languageName: node
+  linkType: hard
+
+"acorn@npm:^8.16.0":
+  version: 8.17.0
+  resolution: "acorn@npm:8.17.0"
+  bin:
+    acorn: bin/acorn
+  checksum: 10c0/5dcefea5f8f023b6cc24cbe71fb5a8112b601d36c4fa07d14e4e6ffc2ee47383332c46b36c766d9437725aa6660156eae50efa0c838719823b50d7c327c4ed42
   languageName: node
   linkType: hard
 
@@ -3595,6 +3812,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^15.0.0":
+  version: 15.0.0
+  resolution: "commander@npm:15.0.0"
+  checksum: 10c0/539229c171914ea1ccd45ee5f10d924289a12a684ea3a7a44147abe54003c35ed6de9ae4ad198d88c29fdf403dca0428451a388234e6dc01b6faa978fb207206
+  languageName: node
+  linkType: hard
+
 "commander@npm:^4.0.0":
   version: 4.1.1
   resolution: "commander@npm:4.1.1"
@@ -3659,6 +3883,13 @@ __metadata:
     conc: dist/bin/concurrently.js
     concurrently: dist/bin/concurrently.js
   checksum: 10c0/da37f239f82eb7ac24f5ddb56259861e5f1d6da2ade7602b6ea7ad3101b13b5ccec02a77b7001402d1028ff2fdc38eed55644b32853ad5abf30e057002a963aa
+  languageName: node
+  linkType: hard
+
+"confbox@npm:^0.1.8":
+  version: 0.1.8
+  resolution: "confbox@npm:0.1.8"
+  checksum: 10c0/fc2c68d97cb54d885b10b63e45bd8da83a8a71459d3ecf1825143dd4c7f9f1b696b3283e07d9d12a144c1301c2ebc7842380bdf0014e55acc4ae1c9550102418
   languageName: node
   linkType: hard
 
@@ -4198,6 +4429,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "es-module-lexer@npm:2.3.0"
+  checksum: 10c0/14b28d854ec2aec285c481daeea268451e01ab2813f09f98eb1ac432521d8c3b38ce552a49f2e4af3ba188b74acbafe9e8d7271ce912bd98f1651b02bd06717e
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -4391,6 +4629,95 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/ccd51f0555708bc9ff4ec9dc3ac92d3daacd45ecaac949ca8645984c5c323bf8cefe98c2df307418685e0b4ce37f9a3bdbfe8e3651fe632a0059a436195a17d4
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.28.1":
+  version: 0.28.1
+  resolution: "esbuild@npm:0.28.1"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.28.1"
+    "@esbuild/android-arm": "npm:0.28.1"
+    "@esbuild/android-arm64": "npm:0.28.1"
+    "@esbuild/android-x64": "npm:0.28.1"
+    "@esbuild/darwin-arm64": "npm:0.28.1"
+    "@esbuild/darwin-x64": "npm:0.28.1"
+    "@esbuild/freebsd-arm64": "npm:0.28.1"
+    "@esbuild/freebsd-x64": "npm:0.28.1"
+    "@esbuild/linux-arm": "npm:0.28.1"
+    "@esbuild/linux-arm64": "npm:0.28.1"
+    "@esbuild/linux-ia32": "npm:0.28.1"
+    "@esbuild/linux-loong64": "npm:0.28.1"
+    "@esbuild/linux-mips64el": "npm:0.28.1"
+    "@esbuild/linux-ppc64": "npm:0.28.1"
+    "@esbuild/linux-riscv64": "npm:0.28.1"
+    "@esbuild/linux-s390x": "npm:0.28.1"
+    "@esbuild/linux-x64": "npm:0.28.1"
+    "@esbuild/netbsd-arm64": "npm:0.28.1"
+    "@esbuild/netbsd-x64": "npm:0.28.1"
+    "@esbuild/openbsd-arm64": "npm:0.28.1"
+    "@esbuild/openbsd-x64": "npm:0.28.1"
+    "@esbuild/openharmony-arm64": "npm:0.28.1"
+    "@esbuild/sunos-x64": "npm:0.28.1"
+    "@esbuild/win32-arm64": "npm:0.28.1"
+    "@esbuild/win32-ia32": "npm:0.28.1"
+    "@esbuild/win32-x64": "npm:0.28.1"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/29cd456a79ce35ac2c7e05fe871330416b2c395c045d849653f843e51378d6e0d6e774d6dcd01b35f4e83238a29bf8decd04fcd34b3780c589a250b21e5f92bb
   languageName: node
   linkType: hard
 
@@ -5054,6 +5381,17 @@ __metadata:
     locate-path: "npm:^6.0.0"
     path-exists: "npm:^4.0.0"
   checksum: 10c0/062c5a83a9c02f53cdd6d175a37ecf8f87ea5bbff1fdfb828f04bfa021441bc7583e8ebc0872a4c1baab96221fb8a8a275a19809fb93fbc40bd69ec35634069a
+  languageName: node
+  linkType: hard
+
+"fix-dts-default-cjs-exports@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "fix-dts-default-cjs-exports@npm:1.0.1"
+  dependencies:
+    magic-string: "npm:^0.30.17"
+    mlly: "npm:^1.7.4"
+    rollup: "npm:^4.34.8"
+  checksum: 10c0/61a3cbe32b6c29df495ef3aded78199fe9dbb52e2801c899fe76d9ca413d3c8c51f79986bac83f8b4b2094ebde883ddcfe47b68ce469806ba13ca6ed4e7cd362
   languageName: node
   linkType: hard
 
@@ -6316,6 +6654,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mlly@npm:^1.7.4":
+  version: 1.8.2
+  resolution: "mlly@npm:1.8.2"
+  dependencies:
+    acorn: "npm:^8.16.0"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^1.3.1"
+    ufo: "npm:^1.6.3"
+  checksum: 10c0/aa826683a6daddf2aef65f9c8142e362731cf8e415a5591faf92fd51040a76697e45ab6dbb7a3b38be74e0f8c464825a7eabe827750455c7472421953f5da733
+  languageName: node
+  linkType: hard
+
 "mnemonist@npm:0.40.0":
   version: 0.40.0
   resolution: "mnemonist@npm:0.40.0"
@@ -6664,7 +7014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pathe@npm:^2.0.3":
+"pathe@npm:^2.0.1, pathe@npm:^2.0.3":
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
   checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
@@ -6796,6 +7146,17 @@ __metadata:
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
   checksum: 10c0/00d5fa51f8dded94d7429700fb91a0c1ead00ae2c7fd27089f0c5b63e6eca36197fe46384631872690a66f390c5e27198e99006ab77ae472692ab9c2ca903f36
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "pkg-types@npm:1.3.1"
+  dependencies:
+    confbox: "npm:^0.1.8"
+    mlly: "npm:^1.7.4"
+    pathe: "npm:^2.0.1"
+  checksum: 10c0/19e6cb8b66dcc66c89f2344aecfa47f2431c988cfa3366bdfdcfb1dd6695f87dcce37fbd90fe9d1605e2f4440b77f391e83c23255347c35cf84e7fd774d7fcea
   languageName: node
   linkType: hard
 
@@ -7641,6 +8002,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:^0.7.6":
+  version: 0.7.6
+  resolution: "source-map@npm:0.7.6"
+  checksum: 10c0/59f6f05538539b274ba771d2e9e32f6c65451982510564438e048bc1352f019c6efcdc6dd07909b1968144941c14015c2c7d4369fb7c4d7d53ae769716dcc16c
+  languageName: node
+  linkType: hard
+
 "source-map@npm:~0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
@@ -8119,6 +8487,48 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsup@npm:^8.5.1":
+  version: 8.5.1
+  resolution: "tsup@npm:8.5.1"
+  dependencies:
+    bundle-require: "npm:^5.1.0"
+    cac: "npm:^6.7.14"
+    chokidar: "npm:^4.0.3"
+    consola: "npm:^3.4.0"
+    debug: "npm:^4.4.0"
+    esbuild: "npm:^0.27.0"
+    fix-dts-default-cjs-exports: "npm:^1.0.0"
+    joycon: "npm:^3.1.1"
+    picocolors: "npm:^1.1.1"
+    postcss-load-config: "npm:^6.0.1"
+    resolve-from: "npm:^5.0.0"
+    rollup: "npm:^4.34.8"
+    source-map: "npm:^0.7.6"
+    sucrase: "npm:^3.35.0"
+    tinyexec: "npm:^0.3.2"
+    tinyglobby: "npm:^0.2.11"
+    tree-kill: "npm:^1.2.2"
+  peerDependencies:
+    "@microsoft/api-extractor": ^7.36.0
+    "@swc/core": ^1
+    postcss: ^8.4.12
+    typescript: ">=4.5.0"
+  peerDependenciesMeta:
+    "@microsoft/api-extractor":
+      optional: true
+    "@swc/core":
+      optional: true
+    postcss:
+      optional: true
+    typescript:
+      optional: true
+  bin:
+    tsup: dist/cli-default.js
+    tsup-node: dist/cli-node.js
+  checksum: 10c0/86b0a5ee5533cf5363431ffaf6a244d06fbc80e3a739f216a121a336b28e663d521bae1d3b2d9ba7d479cb4b5f7dcb5e0722e169d3daf664c78f0d68676fa06a
+  languageName: node
+  linkType: hard
+
 "tsx@npm:^4.19.3":
   version: 4.19.3
   resolution: "tsx@npm:4.19.3"
@@ -8252,6 +8662,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ufo@npm:^1.6.3":
+  version: 1.6.4
+  resolution: "ufo@npm:1.6.4"
+  checksum: 10c0/3a2b29e7e3d772fbf6893d7d23bf442981457adb2fe122828abdbda89bedcb81aafd0dcc080e41b45f9a877db00cb42cbfee9639753a19d9b9bd39b5627039cf
+  languageName: node
+  linkType: hard
+
 "uid@npm:2.0.2":
   version: 2.0.2
   resolution: "uid@npm:2.0.2"
@@ -8272,6 +8689,13 @@ __metadata:
   version: 6.20.0
   resolution: "undici-types@npm:6.20.0"
   checksum: 10c0/68e659a98898d6a836a9a59e6adf14a5d799707f5ea629433e025ac90d239f75e408e2e5ff086afc3cace26f8b26ee52155293564593fbb4a2f666af57fc59bf
+  languageName: node
+  linkType: hard
+
+"undici-types@npm:~6.21.0":
+  version: 6.21.0
+  resolution: "undici-types@npm:6.21.0"
+  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

New package `@fishjam-cloud/composition-cli` — a CLI that scaffolds and builds composition template bundles

- `composition-cli init <dir>` — scaffolds a template project (package.json with supported dependency versions, tsconfig, hello-world `src/App.tsx`)
- `composition-cli build [entry]` — bundles the template and validates it locally against the platform contract, so contract violations fail at build time with named reasons instead of at upload with an opaque `Invalid user bundle`

For now validation uses manifest v1 that is compatible with foundry template worker environment, but we're planning to add  version management in templates API so the validation step may possibly change later