### PR TITLE
[FCE-2925] Document @fishjam-cloud/composition usage

### DIFF
--- a/packages/composition/README.md
+++ b/packages/composition/README.md
@@ -2,7 +2,163 @@
 
 # @fishjam-cloud/composition
 
-JS utilities for building Fishjam composition templates.
+React hooks and an event bus for building **Fishjam composition templates** — server-side
+[Smelter](https://smelter.dev) scenes that mix the tracks forwarded from a Fishjam room into a single
+composed output stream (for broadcasting, recording, HLS, etc.).
+
+A template is a plain React component. It uses [`@swmansion/smelter`](https://smelter.dev) components for
+layout (`View`, `Tiles`, `InputStream`, …) and the hooks from this package to read the live state of the
+linked room. Fishjam forwards each room track to the composition as a Smelter input; this package keeps a
+store of that room state up to date and re-renders your template as peers, tracks and voice-activity change.
+
+## Installation
+
+Templates are normally scaffolded with the companion CLI `@fishjam-cloud/composition-cli`, which wires up
+this package, `@swmansion/smelter` and React for you:
+
+```bash
+npx @fishjam-cloud/composition-cli init my-template
+cd my-template
+npm install
+```
+
+To add it to an existing template project:
+
+```bash
+npm install @fishjam-cloud/composition @swmansion/smelter react
+```
+
+`react` (>= 18) is a peer dependency.
+
+## A minimal template
+
+A template must **default-export a React component**. Compose the forwarded inputs with Smelter components
+and drive the layout from the room state returned by the hooks:
+
+```tsx
+import { InputStream, Tiles, Text, View } from '@swmansion/smelter';
+import { usePeers } from '@fishjam-cloud/composition';
+
+export default function App() {
+  const peers = usePeers();
+
+  if (peers.length === 0) {
+    return (
+      <View style={{ backgroundColor: '#0b1020ff' }}>
+        <Text style={{ fontSize: 48, color: '#ffffff' }}>Waiting for participants…</Text>
+      </View>
+    );
+  }
+
+  return (
+    <Tiles style={{ backgroundColor: '#0b1020ff' }}>
+      {peers
+        .filter((peer) => peer.cameraStream)
+        .map((peer) => (
+          <InputStream key={peer.id} inputId={peer.cameraStream!.inputId} />
+        ))}
+    </Tiles>
+  );
+}
+```
+
+The `inputId` on a stream is the handle you pass to Smelter's `<InputStream inputId={…} />` — it identifies
+the forwarded track inside the composition.
+
+## Reacting to peers and events
+
+The store is fed by the composition host from the room's Fishjam notifications (peers connecting and
+disconnecting, tracks being forwarded or removed, metadata and voice-activity updates). The hooks read it
+through React's `useSyncExternalStore`, so your template re-renders automatically whenever the room changes —
+you never subscribe to raw events yourself.
+
+### Hooks
+
+- **`usePeers<PeerMetadata, ServerMetadata>(): PeerWithStreams[]`** — every peer in the linked room. The
+  composition worker is not a peer, so this is a flat list.
+- **`usePeer(peerId): PeerWithStreams | undefined`** — a single peer by id.
+- **`useRoom(): { id: string } | undefined`** — the linked room's id, or `undefined` before a room is linked.
+- **`useSpeakingState(peerId): 'speech' | 'silence'`** — voice-activity for a peer, useful for
+  active-speaker layouts and highlighting.
+
+Each `PeerWithStreams` splits a peer's forwarded inputs by role so you don't have to inspect track metadata
+yourself:
+
+```tsx
+peer.cameraStream;      // camera video + microphone audio (Stream | undefined)
+peer.screenShareStream; // screen-share video/audio (Stream | undefined)
+peer.customStreams;     // any other forwarded streams (Stream[])
+peer.streams;           // all of the above, flat (Stream[])
+peer.metadata;          // { peer: PeerMetadata; server: ServerMetadata }
+```
+
+A `Stream` carries at most one `video` and one `audio` track (`{ inputId, video?, audio? }`); each track
+exposes a `paused` flag mirroring its mute state, plus its `metadata`. Pass the metadata generics to
+`usePeers`/`usePeer` to type `peer.metadata` for your app.
+
+An active-speaker example:
+
+```tsx
+import { InputStream, View } from '@swmansion/smelter';
+import { useSpeakingState } from '@fishjam-cloud/composition';
+
+function Tile({ peerId, inputId }: { peerId: string; inputId: string }) {
+  const speaking = useSpeakingState(peerId) === 'speech';
+  return (
+    <View style={{ borderWidth: speaking ? 4 : 0, borderColor: '#22c55e' }}>
+      <InputStream inputId={inputId} />
+    </View>
+  );
+}
+```
+
+### Custom events
+
+Beyond room state, the host can push application-defined events into the running composition. Subscribe with
+the global `eventBus`; `on` returns an unsubscribe function:
+
+```tsx
+import { eventBus } from '@fishjam-cloud/composition';
+
+const off = eventBus.on<{ layout: string }>('setLayout', (data) => {
+  // react to a custom event, e.g. switch layouts
+});
+```
+
+### Host integration (`./core`)
+
+The `@fishjam-cloud/composition/core` entry point exposes `compositionStore` and the `CompositionStoreFeed`
+interface (`seedFromRoom`, `applyNotification`, `reset`). This is the surface the **composition host** uses to
+feed the store from `FishjamWSNotifier` events — template authors do not need it.
+
+## Building and bundling
+
+Templates are bundled with `@fishjam-cloud/composition-cli`:
+
+```bash
+npm run build   # runs `composition-cli build`
+```
+
+The CLI bundles your entry (default `src/App.tsx`) with esbuild into a single ESM file at `dist/App.js` and
+validates it against the platform contract:
+
+- the bundle must **default-export a React component**;
+- only these imports are allowed: `react`, `react/jsx-runtime`, `react/jsx-dev-runtime`,
+  `@swmansion/smelter`, `@fishjam-cloud/composition` (they are provided by the runtime, so they stay external
+  and out of your bundle);
+- no `import.meta` or dynamic imports with a non-literal specifier;
+- the bundle must load without blocking the event loop, and stay under the upload size limit.
+
+Upload the built `dist/App.js` as the `template` field when registering a composition output. See
+`@fishjam-cloud/composition-cli` for the full CLI reference.
+
+## How it connects to Fishjam
+
+The bundled template runs inside a server-side Smelter worker (the composition host). When a composition
+output is registered for a room, Fishjam forwards the room's tracks to that worker as Smelter inputs and
+streams the room's notifications to it. The host seeds and updates `compositionStore` from those
+notifications, your template reads the state through the hooks and lays the inputs out with Smelter
+components, and Smelter renders the result into a single composed output stream.
 
 ## License
 


### PR DESCRIPTION
## What

Expands the `@fishjam-cloud/composition` package README (previously a one-line stub) into a full usage guide.

## Where

`packages/composition/README.md` in `js-server-sdk`.

Chose the package README because that is where the code lives and it matches the repo convention — every package here has a README, and the sibling `composition-cli` README already carries real usage docs. The `documentation`/`website` Docusaurus sites have no composition/smelter pages yet, so nothing to extend there.

## Contents

- Install (via `composition-cli init`, or manual).
- Minimal template: a default-exported React component using `usePeers()` + Smelter `Tiles`/`InputStream`.
- Reacting to peers/events: `usePeers`/`usePeer`/`useRoom`/`useSpeakingState`, the `PeerWithStreams` role split (`cameraStream`/`screenShareStream`/`customStreams`), the `Stream`/`TrackState` shape, active-speaker example, and the `eventBus` for custom events.
- Host-facing `./core` (`compositionStore` / `CompositionStoreFeed`) noted as not-for-template-authors.
- Build/bundle with `composition-cli` (single ESM `dist/App.js`, allowed-imports contract, default-export + size validation).
- How it connects to Fishjam/foundry (server-side Smelter worker composing forwarded room tracks into one output stream).

Everything is grounded in the package source (`hooks.ts`, `types.ts`, `store.ts`, `eventBus.ts`, `index.ts`), the CLI (`init.ts`, `build.ts`, `validate.ts`, `smoke.ts`, `manifests/v1.ts`), and the `@swmansion/smelter` exports — no invented APIs.

## Open questions

- **`composition-cli` not on `main` yet.** This branch is based on `origin/main`, where the `composition-cli` package isn't merged. The guide references it by npm name (no broken repo-relative links) since it ships alongside; if it should stay on a feature branch, the build section may need adjusting.
- **Docs-site coverage.** Should this also land as a how-to page in the `documentation` Docusaurus site (e.g. `docs/how-to/backend/`)? Left out for now since there's no existing composition/smelter section to match.
- Exact wording of the foundry/host runtime boundary (who registers the composition output, transport of the final stream) — kept deliberately high-level; happy to tighten with the foundry team's preferred terminology.