### PR TITLE
Remove committed banner image from README, keep adserver banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-<img src="./.github/images/fishjam-card.png" width="100%">
-
-[![Ad](https://swm-delivery.com/www/images/zone-gh-fishjam-1?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-fishjam-1&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-fishjam-2?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-fishjam-2&n=1)
-[![Ad](https://swm-delivery.com/www/images/zone-gh-fishjam-3?n=1)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-fishjam-3&n=1)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-fishjam-1?n=2)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-fishjam-1&n=2)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-fishjam-2?n=2)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-fishjam-2&n=2)
+[![Ad](https://swm-delivery.com/www/images/zone-gh-fishjam-3?n=2)](https://swm-delivery.com/www/delivery/ck.php?zoneid=zone-gh-fishjam-3&n=2)
 
 # Fishjam Server SDK
 


### PR DESCRIPTION
Removes the committed `fishjam-card.png` header from the README so the banner is served exclusively via the swm-delivery adserver links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)