### PR TITLE
Prepare composition-cli for its first npm release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         package: [js-server-sdk, composition, composition-cli]
 

--- a/packages/composition-cli/package.json
+++ b/packages/composition-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/composition-cli",
-  "version": "0.29.0-rc.2",
+  "version": "0.29.0",
   "description": "CLI for scaffolding and building Fishjam composition templates",
   "license": "Apache-2.0",
   "homepage": "https://github.com/fishjam-cloud/js-server-sdk",

--- a/packages/composition-cli/src/init.ts
+++ b/packages/composition-cli/src/init.ts
@@ -45,7 +45,7 @@ export async function scaffoldTemplate(dir: string, manifest: Manifest, cliVersi
     },
     devDependencies: sortKeys({
       ...manifest.scaffoldDevDependencies,
-      '@fishjam-cloud/composition-cli': cliVersion,
+      ...Object.fromEntries(manifest.scaffoldCliVersionDevDependencies.map((name) => [name, cliVersion])),
     }),
   };
 

--- a/packages/composition-cli/src/manifests/types.ts
+++ b/packages/composition-cli/src/manifests/types.ts
@@ -10,4 +10,5 @@ export interface Manifest {
     jsxImportSource: string;
   };
   scaffoldDevDependencies: Record<string, string>;
+  scaffoldCliVersionDevDependencies: string[];
 }

--- a/packages/composition-cli/src/manifests/v1.ts
+++ b/packages/composition-cli/src/manifests/v1.ts
@@ -18,10 +18,10 @@ export const v1: Manifest = {
     jsxImportSource: 'react',
   },
   scaffoldDevDependencies: {
-    '@fishjam-cloud/composition': '0.29.0-rc.2',
     '@swmansion/smelter': '0.3.0',
     '@types/react': '^18.3.0',
     react: '^18.3.1',
     typescript: '^5.6.0',
   },
+  scaffoldCliVersionDevDependencies: ['@fishjam-cloud/composition', '@fishjam-cloud/composition-cli'],
 };

--- a/packages/composition-cli/tests/init.test.ts
+++ b/packages/composition-cli/tests/init.test.ts
@@ -25,6 +25,7 @@ describe('scaffoldTemplate', () => {
     expect(pkg.scripts.build).toContain('composition-cli build');
     expect(pkg.devDependencies).toMatchObject(manifest.scaffoldDevDependencies);
     expect(pkg.devDependencies['@fishjam-cloud/composition-cli']).toBe('1.2.3');
+    expect(pkg.devDependencies['@fishjam-cloud/composition']).toBe('1.2.3');
 
     const tsconfig = JSON.parse(await readFile(join(target, 'tsconfig.json'), 'utf8'));
     expect(tsconfig.compilerOptions.jsx).toBe('react-jsx');
@@ -37,6 +38,12 @@ describe('scaffoldTemplate', () => {
     const gitignore = await readFile(join(target, '.gitignore'), 'utf8');
     expect(gitignore).toContain('node_modules');
     expect(gitignore).toContain('dist');
+  });
+
+  it('never pins a fishjam package to a hardcoded version', async () => {
+    expect(Object.keys(manifest.scaffoldDevDependencies).filter((name) => name.startsWith('@fishjam-cloud/'))).toEqual(
+      []
+    );
   });
 
   it('normalizes the directory name into a valid npm package name', async () => {


### PR DESCRIPTION
Bumps `@fishjam-cloud/composition-cli` from `0.29.0-rc.2` to `0.29.0`, in line with the rest of the repo.

Manifest v1 hardcoded `@fishjam-cloud/composition: 0.29.0-rc.2` in `scaffoldDevDependencies`. `bump-version.sh` only rewrites `package.json` version fields, so that string was invisible to the release automation and every release would leave it pointing at an old version. It fails quietly too: the stale version still installs, so a scaffolded template just silently gets an rc.

Fishjam deps are now listed in `scaffoldCliVersionDevDependencies` and pinned to the CLI's own version at scaffold time. The repo is versioned in lockstep, so that is the right number. Added a test that fails if anyone hardcodes a `@fishjam-cloud/*` version in the manifest again.

Also sets `fail-fast: false` on the release matrix. The three packages are independent npm publishes, and today one failure cancels the others mid-release.

Note: `@fishjam-cloud/composition-cli` does not exist on npm yet, and the release workflow publishes via OIDC trusted publishing, which is configured per package. The first publish needs to be done manually, as was done for `@fishjam-cloud/composition`.